### PR TITLE
Improve navigation with direction toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,10 @@
 </head>
 <body>
 
-    <div id="grid"></div>
+    <div>
+        <button id="toggle-direction">Mode: Across</button>
+        <div id="grid"></div>
+    </div>
 
     <div id="clues">
         <div class="clue-group" id="clues-across">


### PR DESCRIPTION
## Summary
- enable across/down mode toggle button next to the crossword grid
- add new functions for updating direction state
- auto-advance now attempts the other direction if blocked
- implement backspace navigation to previous cell

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68548230b8048325868f446953d9ea31