### PR TITLE
Add feature to check current word

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,8 @@
     <div>
         <button id="toggle-direction">Mode: Across</button>
         <button id="check-answer">Check Answers</button>
+        <button id="check-current-across">Check Across</button>
+        <button id="check-current-down">Check Down</button>
         <div id="grid"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- add dedicated buttons to check across or down answers
- implement functions to gather word cells and check correctness
- color cell text green when correct and red when incorrect
- reset color when typing or erasing letters

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6854871e224c8325af1b38a12d7296f8