### PR TITLE
Improve crossword UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             display: flex;
             flex-direction: row;
             gap: 2rem;
-            background-color: #fff8e8; /* pastel background */
+            background-color: #eef6ff; /* pastel blue background */
         }
 
         #grid {
@@ -20,6 +20,8 @@
             gap: 2px;
             border: 1px solid #000;
             position: relative;
+            background-color: #ffffff; /* keep grid white */
+            margin-top: 15px; /* spacing from buttons */
         }
 
         .cell {
@@ -36,7 +38,7 @@
 
         .cell.selected {
             outline: 2px solid #333;
-            background-color: #ffffcc;
+            background-color: #e6f0ff; /* faint blue */
         }
 
         .cell.highlight {
@@ -45,9 +47,10 @@
 
         .cell .num {
             position: absolute;
-            top: 0;
+            top: 1px;
             left: 2px;
             font-size: 10px;
+            line-height: 10px;
         }
 
         /* Button styling */
@@ -56,7 +59,7 @@
             border: 1px solid #888;
             border-radius: 4px;
             padding: 0.4em 0.8em;
-            margin-right: 0.5em;
+            margin-bottom: 0.5em;
             cursor: pointer;
         }
         button:hover {
@@ -77,10 +80,19 @@
 
         .clue-num {
             font-weight: bold;
-            margin-right: 0.3em;
+            margin-right: 0.6em;
             display: inline-block;
             width: 2em;
-            text-align: right;
+            text-align: left; /* left justify numbers */
+        }
+
+        #clues li {
+            margin-bottom: 1em; /* spacing between clues */
+        }
+
+        #controls {
+            display: flex;
+            flex-direction: column;
         }
 
         #clues {
@@ -95,7 +107,7 @@
 </head>
 <body>
 
-    <div>
+    <div id="controls">
         <button id="toggle-direction">Mode: Across</button>
         <button id="check-answer">Check Answers</button>
         <button id="check-current-across">Check Across</button>


### PR DESCRIPTION
## Summary
- adjust grid, clue, and button styling
- apply a pastel blue background with white grid
- left-align clue numbers with better spacing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68548c2d402483258769095ad8454236