### PR TITLE
Improve mobile usability for crossword

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,30 @@
             flex: 1;
         }
 
+        #mobile-input {
+            position: absolute;
+            opacity: 0;
+            left: -9999px;
+            width: 1px;
+            height: 1px;
+            border: none;
+        }
+
+        @media (max-width: 600px) {
+            body {
+                flex-direction: column;
+                margin: 1rem;
+                align-items: center;
+            }
+            #clues {
+                flex-direction: column;
+                max-width: none;
+            }
+            #grid {
+                margin-bottom: 1rem;
+            }
+        }
+
     </style>
 </head>
 <body>
@@ -126,6 +150,7 @@
             <button id="check-current-down">Check Down</button>
         </div>
         <div id="grid"></div>
+        <input id="mobile-input" type="text" inputmode="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
     </div>
 
     <div id="clues">

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ let highlightedCells = [];
 let currentDirection = 'across';
 let directionButton = null;
 let checkButton = null;
+let mobileInput = null;
 
 function parsePuzzleData(xmlString) {
   const parser = new DOMParser();
@@ -75,6 +76,7 @@ function createCellElement(cellData, x, y) {
       cell.appendChild(num);
     }
     cell.addEventListener('click', () => selectCell(cell));
+    cell.addEventListener('touchstart', () => selectCell(cell));
   }
 
   return cell;
@@ -133,6 +135,10 @@ function selectCell(cell) {
   selectedCell = cell;
   selectedCell.classList.add('selected');
   highlightWord(selectedCell);
+  if (mobileInput) {
+    mobileInput.value = '';
+    mobileInput.focus();
+  }
 }
 
 function testGridIsBuilt() {
@@ -321,6 +327,30 @@ if (checkAcrossBtn) {
 const checkDownBtn = document.getElementById('check-current-down');
 if (checkDownBtn) {
     checkDownBtn.addEventListener('click', () => checkCurrentAnswer('down'));
+}
+
+mobileInput = document.getElementById('mobile-input');
+if (mobileInput) {
+    mobileInput.addEventListener('input', (e) => {
+        const val = mobileInput.value;
+        if (!val) return;
+        const letter = val.slice(-1);
+        mobileInput.value = '';
+        if (/^[a-zA-Z]$/.test(letter) && selectedCell) {
+            selectedCell.style.color = '';
+            selectedCell.textContent = letter.toUpperCase();
+            autoAdvance();
+        }
+    });
+    mobileInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Backspace') {
+            e.preventDefault();
+            handleBackspace();
+        } else if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+            e.preventDefault();
+            moveSelection(e.key);
+        }
+    });
 }
 
 document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- hide a small off-screen input for mobile typing
- switch layout to column on small screens
- support touch events and focus on the hidden input

## Testing
- `node --check main.js`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6854924e7ca8832592295c2208ed6cbc