### PR TITLE
Highlight clue for selected word

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,6 +107,7 @@ function buildClues(across, down) {
 
   across.forEach(cl => {
     const li = document.createElement('li');
+    li.dataset.number = cl.number;
     const num = document.createElement('span');
     num.className = 'clue-num';
     num.textContent = cl.number;
@@ -117,6 +118,7 @@ function buildClues(across, down) {
 
   down.forEach(cl => {
     const li = document.createElement('li');
+    li.dataset.number = cl.number;
     const num = document.createElement('span');
     num.className = 'clue-num';
     num.textContent = cl.number;
@@ -246,6 +248,19 @@ function highlightWord(cell) {
         el.classList.add('highlight');
         highlightedCells.push(el);
     });
+
+    // highlight matching clue
+    document.querySelectorAll('#clues li.highlight').forEach(li => li.classList.remove('highlight'));
+    const clueNumber = cells.length > 0 ? cells[0].data.number : null;
+    if (clueNumber) {
+        const selector = currentDirection === 'across'
+            ? `#clues-across li[data-number="${clueNumber}"]`
+            : `#clues-down li[data-number="${clueNumber}"]`;
+        const clueEl = document.querySelector(selector);
+        if (clueEl) {
+            clueEl.classList.add('highlight');
+        }
+    }
 }
 
 function checkCurrentAnswer(direction) {

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,10 @@
             margin-bottom: 1em; /* spacing between clues */
         }
 
+        #clues li.highlight {
+            background-color: #fff4a3;
+        }
+
         #controls {
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
## Summary
- add data-number attribute to each clue element
- highlight matching clue when a word is selected
- style highlighted clues

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549963fd808325855f1109868ba452