### PR TITLE
Toggle direction by reselecting cell

### DIFF
--- a/main.js
+++ b/main.js
@@ -132,6 +132,15 @@ function selectCell(cell) {
   if (cell.classList.contains('block')) {
     return;
   }
+
+  // if clicking the currently selected cell, toggle direction
+  if (selectedCell === cell) {
+    currentDirection = currentDirection === 'across' ? 'down' : 'across';
+    highlightWord(cell);
+    updateDirectionButton();
+    return;
+  }
+
   if (selectedCell) {
     selectedCell.classList.remove('selected');
   }


### PR DESCRIPTION
## Summary
- update `selectCell` to detect when the same cell is clicked again
- toggle the direction and refresh highlights when reselecting a cell

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549a0d9a448325834e9bccf9aeae15