### PR TITLE
Prevent duplicate input on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,12 @@ testCluesPresent(); // should return true if clues are present
 - There is no build system or dependency installation. Open `index.html` in a
   browser to run the viewer and access helper functions such as
   `testGridIsBuilt()` and `testCluesPresent()` from the developer console.
+
+## Notes for Future Contributors
+
+- Mobile text entry uses a hidden `<input>` element (`#mobile-input`).
+  Characters typed there trigger its `input` handler. A document-level `keydown`
+  listener also handles desktop keyboard events. If that listener fires while
+  the hidden input is focused, letters may be added twice on some mobile
+  browsers. Skip handling in the document listener when
+  `document.activeElement === mobileInput` to prevent duplicate entry.

--- a/main.js
+++ b/main.js
@@ -380,6 +380,10 @@ if (mobileInput) {
 
 document.addEventListener('keydown', (e) => {
     if (!selectedCell) return;
+    if (mobileInput && document.activeElement === mobileInput) {
+        // Prevent double character entry when the hidden mobile input is focused
+        return;
+    }
     const key = e.key;
     if (/^[a-zA-Z]$/.test(key)) {
         selectedCell.style.color = '';


### PR DESCRIPTION
## Summary
- avoid document-level keydown handling when the hidden mobile input has focus
- document mobile input quirk in AGENTS.md

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68549aa4fc388325b192054268b4af8f