### PR TITLE
Fix down clue highlighting

### DIFF
--- a/main.js
+++ b/main.js
@@ -146,6 +146,17 @@ function selectCell(cell) {
   }
   selectedCell = cell;
   selectedCell.classList.add('selected');
+  // auto-adjust direction if the current one has no word
+  let cells = getWordCells(selectedCell, currentDirection);
+  if (cells.length <= 1) {
+    const other = currentDirection === 'across' ? 'down' : 'across';
+    const otherCells = getWordCells(selectedCell, other);
+    if (otherCells.length > cells.length) {
+      currentDirection = other;
+      cells = otherCells;
+      updateDirectionButton();
+    }
+  }
   highlightWord(selectedCell);
   if (mobileInput) {
     mobileInput.value = '';


### PR DESCRIPTION
## Summary
- adjust selected cell logic to automatically switch direction when no word exists in current direction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549b5eca5c8325bafc580982e18d64