### PR TITLE
Fix mobile button alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,7 @@
             body {
                 flex-direction: column;
                 margin: 1rem;
-                align-items: center;
+                align-items: flex-start;
             }
             #clues {
                 flex-direction: column;


### PR DESCRIPTION
## Summary
- buttons were cut off on mobile because the body centered its children in the media query
- keep the column layout on small screens but left-align the content so nothing is clipped

## Testing
- `node -e "console.log('Checking Node works')"`
- `node -e "require('jsdom')"` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68549bfc4cd08325b6a4682219ef72e6