### PR TITLE
Fix double tap issue on mobile

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,8 +76,12 @@ function createCellElement(cellData, x, y) {
       num.textContent = cellData.number;
       cell.appendChild(num);
     }
-    cell.addEventListener('click', () => selectCell(cell));
-    cell.addEventListener('touchstart', () => selectCell(cell));
+    // use pointer events to handle both mouse and touch in one handler
+    cell.addEventListener('pointerdown', (e) => {
+      selectCell(cell);
+      // prevent generation of a subsequent click event on touch devices
+      e.preventDefault();
+    });
   }
 
   return cell;

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,9 @@
             line-height: 30px;
             cursor: pointer;
             position: relative;
+            /* avoid double events and accidental text selection on mobile */
+            touch-action: manipulation;
+            user-select: none;
         }
 
         .cell.selected {


### PR DESCRIPTION
## Summary
- handle cell taps with `pointerdown` to avoid duplicate click/touch events
- disable text selection and specify `touch-action: manipulation` for cells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549f9809bc8325b801b1f4b49c425d