### PR TITLE
Add debugging hooks for keyboard focus

### DIFF
--- a/main.js
+++ b/main.js
@@ -423,6 +423,21 @@ buildGrid(puzzleData);
 
 buildClues(puzzleData.cluesAcross, puzzleData.cluesDown);
 
+// Debug output to trace focus and pointer events on mobile
+if (mobileInput) {
+    mobileInput.addEventListener('focus', () =>
+        console.log('mobile-input focus', Date.now()));
+    mobileInput.addEventListener('blur', () =>
+        console.log('mobile-input blur', Date.now()));
+}
+
+document.querySelectorAll('#grid .cell').forEach(cell => {
+    ['pointerdown', 'pointerup', 'click'].forEach(ev =>
+        cell.addEventListener(ev, () =>
+            console.log(ev, cell.dataset.x, cell.dataset.y,
+                'active:', document.activeElement.id)));
+});
+
 console.log('Crossword Viewer: Ready');
 
 // Expose test helpers for console usage


### PR DESCRIPTION
## Summary
- log focus/blur on the hidden mobile input
- log pointer events on each cell with the active element

## Testing
- `node --check main.js`
- *(tests unavailable due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6854a13a154083258eb696cb54c05a8d