### PR TITLE
Add localStorage progress persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
             <button id="check-current-across">Check Across</button>
             <button id="check-current-down">Check Down</button>
             <button id="copy-link">Copy Share Link</button>
+            <button id="clear-progress">Clear Progress</button>
         </div>
         <div id="grid"></div>
         <input id="mobile-input" type="text" inputmode="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />


### PR DESCRIPTION
## Summary
- persist crossword progress using localStorage
- load saved state on startup and restore the first cell
- add a button to clear stored progress

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68550a80b74c8325a474df5ce4be2aee