### PR TITLE
Highlight grid from clue click & avoid scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -126,9 +126,10 @@
         }
 
         #mobile-input {
-            position: absolute;
+            position: fixed;
             opacity: 0;
-            left: -9999px;
+            top: 0;
+            left: 0;
             width: 1px;
             height: 1px;
             border: none;


### PR DESCRIPTION
## Summary
- map clues to starting cells when parsing puzzle data
- allow clicking clues to select their word in the grid
- keep hidden mobile input from scrolling the page
- prevent scrolling when focusing the hidden input

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6855110e9ab083259ded5d054ade9a41