### PR TITLE
Implement run‑length compression for share URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ The following helper functions can be run from the browser console:
 - `testCluesPresent()` — returns true if clues are displayed
 - `logGridState()` — logs current cell contents
 - `getShareableURL()` — returns a URL containing the current puzzle state
+
+## Share Link Format
+
+The puzzle state string is compressed with a simple run-length encoding before
+being Base64 encoded. Runs of the same character are replaced with
+`<count><char>` (the count is omitted when it is `1`). The compressed string is
+then passed to `btoa()` for inclusion in the URL. `loadStateFromURL()` performs
+the inverse operation by Base64 decoding and expanding the run-length data.

--- a/main.js
+++ b/main.js
@@ -337,9 +337,41 @@ function applyGridState(serialized) {
     });
 }
 
+function rleEncode(str) {
+    if (!str) return '';
+    let result = '';
+    let count = 1;
+    for (let i = 1; i <= str.length; i++) {
+        if (str[i] === str[i - 1]) {
+            count++;
+        } else {
+            result += (count > 1 ? count : '') + str[i - 1];
+            count = 1;
+        }
+    }
+    return result;
+}
+
+function rleDecode(str) {
+    let result = '';
+    let countStr = '';
+    for (let i = 0; i < str.length; i++) {
+        const ch = str[i];
+        if (ch >= '0' && ch <= '9') {
+            countStr += ch;
+        } else {
+            const count = countStr ? parseInt(countStr, 10) : 1;
+            result += ch.repeat(count);
+            countStr = '';
+        }
+    }
+    return result;
+}
+
 function getShareableURL() {
     const serialized = serializeGridState();
-    const encoded = btoa(serialized);
+    const compressed = rleEncode(serialized);
+    const encoded = btoa(compressed);
     return location.origin + location.pathname + '#state=' + encoded;
 }
 
@@ -353,7 +385,8 @@ function loadStateFromURL() {
     }
     if (encoded) {
         try {
-            const serialized = atob(encoded);
+            const compressed = atob(encoded);
+            const serialized = rleDecode(compressed);
             applyGridState(serialized);
             return true;
         } catch (e) {


### PR DESCRIPTION
## Summary
- add `rleEncode`/`rleDecode` helpers
- compress serialized grid state before `btoa`
- decode and expand state when loading from URL
- document share link format in README

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685536dacd788325a76150544bd67e39