### PR TITLE
Encode share URL params

### DIFF
--- a/main.js
+++ b/main.js
@@ -372,7 +372,8 @@ function getShareableURL() {
     const serialized = serializeGridState();
     const compressed = rleEncode(serialized);
     const encoded = btoa(compressed);
-    return location.origin + location.pathname + '#state=' + encoded;
+    const urlEncoded = encodeURIComponent(encoded);
+    return location.origin + location.pathname + '#state=' + urlEncoded;
 }
 
 function loadStateFromURL() {
@@ -385,7 +386,8 @@ function loadStateFromURL() {
     }
     if (encoded) {
         try {
-            const compressed = atob(encoded);
+            const decoded = decodeURIComponent(encoded);
+            const compressed = atob(decoded);
             const serialized = rleDecode(compressed);
             applyGridState(serialized);
             return true;


### PR DESCRIPTION
## Summary
- encode the puzzle state with `encodeURIComponent()` when generating a shareable link
- decode the value in `loadStateFromURL()` before restoring the puzzle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68553b01bc748325b3b7118046b7cb12