### PR TITLE
Fix input event handling on desktop and mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,5 +99,9 @@ cell elements. This improves performance and simplifies code.
 
 ## Input Handling (2024)
 
-Grid cells are now `contenteditable` and keyboard input is captured from `keydown` events. The handler calls `preventDefault()` to avoid double entry. The previous invisible `mobile-input` element and associated conditionals can be deleted.
+Keyboard input is processed at the document level. Grid cells are
+`contenteditable` so the on‑screen keyboard appears on mobile devices.
+`keydown` events handle desktop entry (calling `preventDefault()` so letters are
+not inserted twice) while `input` events cover mobile browsers that do not
+dispatch `keydown`. The old hidden `mobile-input` element has been removed.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 
 ### Input handling
 
-Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Key presses are captured from `keydown` events and handled programmatically. The event handler calls `preventDefault()` to avoid the browser inserting characters twice.
+Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are handled at the document level: `keydown` covers desktop input while `input` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
 
 ## Testing
 

--- a/main.js
+++ b/main.js
@@ -132,7 +132,7 @@ class Crossword {
         this.selectCell(cell);
         e.preventDefault();
       });
-      cell.addEventListener('keydown', (e) => this.handleKeyDown(e));
+      // Key events are handled at the document level to avoid duplicates
     }
 
     return cell;
@@ -456,6 +456,36 @@ class Crossword {
     }
   }
 
+  handleInput(e) {
+    const cell = e.target.closest('.cell');
+    if (!cell || cell.classList.contains('block')) return;
+    if (cell !== this.selectedCell) {
+      this.selectCell(cell);
+    }
+
+    if (e.inputType && e.inputType.startsWith('delete')) {
+      this.handleBackspace();
+      return;
+    }
+
+    let letter = e.data;
+    if (!letter) {
+      letter = cell.textContent.trim();
+    }
+    Array.from(cell.childNodes).forEach(n => {
+      if (n.nodeType === Node.TEXT_NODE) cell.removeChild(n);
+    });
+    if (!letter) return;
+    letter = letter.slice(-1);
+    if (/^[a-zA-Z]$/.test(letter)) {
+      cell.style.color = '';
+      const letterEl = cell.querySelector('.letter');
+      if (letterEl) letterEl.textContent = letter.toUpperCase();
+      this.autoAdvance();
+      this.saveStateToLocalStorage();
+    }
+  }
+
   getWordCells(cell, direction) {
     if (!cell) return [];
     const x = parseInt(cell.dataset.x, 10);
@@ -607,6 +637,7 @@ function initCrossword(xmlData) {
 
 
   document.addEventListener('keydown', (e) => crossword.handleKeyDown(e));
+  document.addEventListener('input', (e) => crossword.handleInput(e));
 
   crossword.buildGrid();
 


### PR DESCRIPTION
## Summary
- avoid double keydown events by removing per-cell listeners
- add unified `handleInput` so mobile browsers auto-advance
- update event wiring in `main.js`
- document new behaviour in README and AGENTS

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6855346568f483258b3d35a28c482d68