### PR TITLE
Remove old puzzle stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ container's Node environment. Use them from a browser console instead.
 
 ### Marked for Deletion
 - Puzzle data lives in `puzzle.xml` and is fetched at runtime.
+- The obsolete `Social_Deduction.js` stub has been removed; puzzle data now loads exclusively from `puzzle.xml`.
 - There is no build system or dependency installation. Open `index.html` in a
   browser to run the viewer. The helper functions
   `testGridIsBuilt()` and `testCluesPresent()` are available from the

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Parse puzzle data from `puzzle.xml` and render an interactive crossword grid and
 
 - `index.html` — main page
 - `main.js` — JS logic (loaded as an ES module)
-- `Social_Deduction.js` — stub referencing the puzzle
-- `puzzle.xml` — puzzle data in XML format
+- `puzzle.xml` — puzzle data in XML format loaded at runtime via fetch
 
 ## Features
 

--- a/Social_Deduction.js
+++ b/Social_Deduction.js
@@ -1,2 +1,0 @@
-// Puzzle data moved to external file 'puzzle.xml'.
-// The XML is loaded via fetch in main.js.

--- a/index.html
+++ b/index.html
@@ -30,8 +30,6 @@
             <ul></ul>
         </div>
     </div>
-
-    <script src="Social_Deduction.js"></script>
     <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- delete obsolete Social_Deduction.js
- drop Social_Deduction.js from index.html
- remove reference to the stub from README
- note removal in AGENTS instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685572ec4cf483259fd7a4ed5bb99b18