### PR TITLE
Allow clue selection without focusing grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,10 @@ dispatch `keydown`. The old hidden `mobile-input` element has been removed.
 
 Clue numbers and letter containers inside each cell have `contenteditable="false"`
 and ignore pointer events so typing does not modify them directly.
+
+## Optional Focus Parameter (2024)
+
+`selectCell(cell, shouldFocus = true)` selects and highlights a grid cell. When
+`shouldFocus` is `false` the cell is highlighted without moving keyboard focus.
+`selectClue()` uses this to highlight an entry when a clue is clicked without
+focusing the grid.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 
 Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are handled at the document level: `keydown` covers desktop input while `input` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
 
+### Selecting clues
+
+Clicking a clue highlights its answer without shifting keyboard focus. The `selectCell()` function now accepts an optional second parameter `shouldFocus` (default `true`) controlling whether the selected cell gains focus.
+
 ## Testing
 
 To enable verbose diagnostic output while developing, open `main.js` and set the

--- a/main.js
+++ b/main.js
@@ -197,7 +197,7 @@ class Crossword {
     });
   }
 
-  selectCell(cell) {
+  selectCell(cell, shouldFocus = true) {
     if (cell.classList.contains('block')) {
       return;
     }
@@ -225,7 +225,7 @@ class Crossword {
       }
     }
     this.highlightWord(this.selectedCell);
-    if (this.selectedCell.focus) {
+    if (shouldFocus && this.selectedCell.focus) {
       try {
         this.selectedCell.focus({ preventScroll: true });
       } catch (e) {
@@ -546,7 +546,7 @@ class Crossword {
     if (cell) {
       this.currentDirection = direction;
       this.updateDirectionButton();
-      this.selectCell(cell);
+      this.selectCell(cell, false);
     }
   }
 


### PR DESCRIPTION
## Summary
- add optional focus flag to `selectCell`
- keep focus when tapping grid but not when choosing clues
- document new parameter in README
- add Optional Focus parameter section to AGENTS.md

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6855761a9bd08325b3937c3619934f0d