### PR TITLE
Add clue enumeration display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,9 @@ ignored when clicked.
 
 Completed clues also display a subtle line-through decoration so solvers can
 easily distinguish which clues remain unsolved.
+
+## Clue Enumerations (2024)
+
+Clue text now includes enumeration strings pulled directly from the
+`format` attribute in `puzzle.xml`. These strings indicate letter grouping such
+as `7,5` and are displayed in parentheses next to each clue.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Parse puzzle data from `puzzle.xml` and render an interactive crossword grid and
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups
+- Clue enumerations shown using values from `puzzle.xml`
 
 ## Running
 

--- a/main.js
+++ b/main.js
@@ -53,7 +53,8 @@ class Crossword {
       clueSections[0].querySelectorAll('clue').forEach(cl => {
         cluesAcross.push({
           number: cl.getAttribute('number'),
-          text: cl.textContent
+          text: cl.textContent,
+          enumeration: cl.getAttribute('format') || ''
         });
       });
     }
@@ -61,7 +62,8 @@ class Crossword {
       clueSections[1].querySelectorAll('clue').forEach(cl => {
         cluesDown.push({
           number: cl.getAttribute('number'),
-          text: cl.textContent
+          text: cl.textContent,
+          enumeration: cl.getAttribute('format') || ''
         });
       });
     }
@@ -173,7 +175,8 @@ class Crossword {
       num.className = 'clue-num';
       num.textContent = cl.number;
       li.appendChild(num);
-      li.appendChild(document.createTextNode(cl.text + ' (' + cl.length + ')'));
+      const enumStr = cl.enumeration || cl.length;
+      li.appendChild(document.createTextNode(cl.text + ' (' + enumStr + ')'));
       li.addEventListener('pointerdown', (e) => {
         if (li.classList.contains('complete')) return;
         this.selectClue(cl.number, 'across');
@@ -189,7 +192,8 @@ class Crossword {
       num.className = 'clue-num';
       num.textContent = cl.number;
       li.appendChild(num);
-      li.appendChild(document.createTextNode(cl.text + ' (' + cl.length + ')'));
+      const enumStr = cl.enumeration || cl.length;
+      li.appendChild(document.createTextNode(cl.text + ' (' + enumStr + ')'));
       li.addEventListener('pointerdown', (e) => {
         if (li.classList.contains('complete')) return;
         this.selectClue(cl.number, 'down');


### PR DESCRIPTION
## Summary
- parse clue `format` attribute for enumeration strings
- show enumeration next to clue text if available
- document enumeration support in project notes
- mention enumeration display in README

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68557e2e211483258ff53c0b4d2a43e6