### PR TITLE
Improve crossword responsiveness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,16 @@ easily distinguish which clues remain unsolved.
 Clue text now includes enumeration strings pulled directly from the
 `format` attribute in `puzzle.xml`. These strings indicate letter grouping such
 as `7,5` and are displayed in parentheses next to each clue.
+
+## Responsive Grid Sizing (2024)
+
+Grid cell dimensions are controlled by the CSS variable `--cell-size`.
+`buildGrid()` sets this variable to `calc(80vmin / N)` where `N` is the larger of
+the puzzle's width or height. Using `vmin` allows the entire grid to scale with
+the viewport, improving mobile usability.
+
+## On-Screen Arrow Navigation (2024)
+
+`index.html` now includes an `#arrows` container with four buttons. Each button
+has a `data-dir` attribute like `ArrowUp`. In `initCrossword()` these buttons call
+`moveSelection()` so solvers can navigate without a physical keyboard.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Parse puzzle data from `puzzle.xml` and render an interactive crossword grid and
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups
 - Clue enumerations shown using values from `puzzle.xml`
+- Grid cell size scales with the viewport for better mobile support
 
 ## Running
 
@@ -36,6 +37,7 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 ### Input handling
 
 Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are handled at the document level: `keydown` covers desktop input while `input` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
+On-screen arrow buttons allow navigation when no hardware keyboard is available.
 
 ### Selecting clues
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
             <button id="clear-progress">Clear Progress</button>
         </div>
         <div id="grid"></div>
+        <div id="arrows">
+            <button data-dir="ArrowUp">&#x25B2;</button>
+            <button data-dir="ArrowLeft">&#x25C0;</button>
+            <button data-dir="ArrowRight">&#x25B6;</button>
+            <button data-dir="ArrowDown">&#x25BC;</button>
+        </div>
     </div>
 
     <div id="clues">

--- a/main.js
+++ b/main.js
@@ -147,8 +147,10 @@ class Crossword {
     const data = this.puzzleData;
     const gridEl = document.getElementById('grid');
     gridEl.innerHTML = '';
-    gridEl.style.gridTemplateColumns = `repeat(${data.width}, 30px)`;
-    gridEl.style.gridTemplateRows = `repeat(${data.height}, 30px)`;
+    const cellSize = `calc(80vmin / ${Math.max(data.width, data.height)})`;
+    gridEl.style.setProperty('--cell-size', cellSize);
+    gridEl.style.gridTemplateColumns = `repeat(${data.width}, var(--cell-size))`;
+    gridEl.style.gridTemplateRows = `repeat(${data.height}, var(--cell-size))`;
 
     this.cellEls = Array.from({ length: data.height }, () => Array(data.width).fill(null));
 
@@ -715,6 +717,22 @@ function initCrossword(xmlData) {
     crossword.clearProgressButton.addEventListener('click', () => {
       localStorage.removeItem('crosswordState');
       crossword.applyGridState('');
+    });
+  }
+
+  const arrowContainer = document.getElementById('arrows');
+  if (arrowContainer) {
+    arrowContainer.querySelectorAll('button[data-dir]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const dir = btn.dataset.dir;
+        crossword.moveSelection(dir);
+        if (dir === 'ArrowUp' || dir === 'ArrowDown') {
+          crossword.currentDirection = 'down';
+        } else if (dir === 'ArrowLeft' || dir === 'ArrowRight') {
+          crossword.currentDirection = 'across';
+        }
+        crossword.updateDirectionButton();
+      });
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,7 @@
         /* Basic styles for skeleton */
+        :root {
+            --cell-size: 30px;
+        }
         body {
             font-family: sans-serif;
             margin: 2rem;
@@ -18,13 +21,13 @@
         }
 
         .cell {
-            width: 30px;
-            height: 30px;
+            width: var(--cell-size);
+            height: var(--cell-size);
             border: 1px solid #ccc;
             text-align: center;
             vertical-align: middle;
             font-size: 16px;
-            line-height: 30px;
+            line-height: var(--cell-size);
             cursor: pointer;
             position: relative;
             /* avoid double events and accidental text selection on mobile */
@@ -124,6 +127,24 @@
             gap: 0.5em;
             margin-bottom: 1em;
         }
+
+        #arrows {
+            display: grid;
+            grid-template-areas:
+                '. up .'
+                'left . right'
+                '. down .';
+            gap: 0.3em;
+            margin-top: 0.5em;
+        }
+        #arrows button {
+            font-size: 1.2em;
+            padding: 0.2em 0.6em;
+        }
+        #arrows button[data-dir="ArrowUp"] { grid-area: up; }
+        #arrows button[data-dir="ArrowDown"] { grid-area: down; }
+        #arrows button[data-dir="ArrowLeft"] { grid-area: left; }
+        #arrows button[data-dir="ArrowRight"] { grid-area: right; }
 
         #clues {
             display: flex;


### PR DESCRIPTION
## Summary
- scale crossword cell size based on viewport
- add optional on-screen arrow keys for navigation
- document responsive grid and new controls
- record new functionality for future agents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855807b69a08325a2566ed1bb2c88a2