### PR TITLE
Ensure puzzle progress is stored per puzzle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,3 +170,10 @@ Grid numbers and letters now size proportionally to each cell. `.letter`
 elements use about 60% of the cell size while `.num` uses roughly 30%.
 This keeps text legible on desktop without overwhelming tiny cells on
 mobile devices.
+
+## Puzzle-Specific Storage Keys (2025)
+
+Progress in the crossword is stored in `localStorage` under a key derived from
+the puzzle's title. This allows multiple puzzles on the same site to save their
+states independently. The "Clear Progress" button removes the entry using this
+key.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Parse puzzle data from `puzzle.xml` and render an interactive crossword grid and
 - Clues display
 - User can type answers
 - Shareable URLs for puzzle state
+- Progress saved in `localStorage` using a key derived from the puzzle title
 - Basic test functions
 - Diagnostic output in console
 - No server required — runs as static HTML/JS


### PR DESCRIPTION
## Summary
- parse puzzle title in `parsePuzzleData`
- derive a `storageKey` from the title
- use the key in save/load/clear progress logic
- note per‑puzzle storage in README
- document the new feature in AGENTS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68558881e16083258667f91de00eab62