### PR TITLE
Overwrite letters when typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,10 @@ When `TEST_MODE` is `true`, the `checkLetter()` and `checkWord()` methods log
 their comparisons to the console. Each log reports the cell coordinates, the
 expected solution letter, and the actual letter typed. This helps diagnose why a
 cell might not highlight when using the check buttons.
+
+## Overwrite Input (2025)
+
+Typing a letter into a cell now replaces any existing letter in that cell
+automatically. This behavior works for both physical keyboards and mobile
+on-screen keyboards. The helper method `setCellLetter(cell, letter)` handles the
+DOM updates.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Parse puzzle data from `puzzle.xml` and render an interactive crossword grid and
 - Interactive grid
 - Clues display
 - User can type answers
+- Typing a new letter in a cell replaces any existing letter
 - Shareable URLs for puzzle state
 - Basic test functions
 - Diagnostic output in console

--- a/main.js
+++ b/main.js
@@ -268,6 +268,19 @@ class Crossword {
     return false;
   }
 
+  setCellLetter(cell, letter) {
+    if (!cell) return;
+    Array.from(cell.childNodes).forEach(n => {
+      if (n.nodeType === Node.TEXT_NODE) {
+        cell.removeChild(n);
+      }
+    });
+    const letterEl = cell.querySelector('.letter');
+    if (letterEl) {
+      letterEl.textContent = letter.toUpperCase();
+    }
+  }
+
   autoAdvance() {
     let moved = false;
     if (this.currentDirection === 'across') {
@@ -444,8 +457,7 @@ class Crossword {
       e.preventDefault();
       this.clearFeedback();
       this.selectedCell.style.color = '';
-      const letterEl = this.selectedCell.querySelector('.letter');
-      if (letterEl) letterEl.textContent = key.toUpperCase();
+      this.setCellLetter(this.selectedCell, key);
       this.autoAdvance();
       this.saveStateToLocalStorage();
     } else if (key === 'Backspace') {
@@ -490,8 +502,7 @@ class Crossword {
     if (/^[a-zA-Z]$/.test(letter)) {
       this.clearFeedback();
       cell.style.color = '';
-      const letterEl = cell.querySelector('.letter');
-      if (letterEl) letterEl.textContent = letter.toUpperCase();
+      this.setCellLetter(cell, letter);
       this.autoAdvance();
       this.saveStateToLocalStorage();
     }


### PR DESCRIPTION
## Summary
- overwrite old letters when typing a new one
- document new behaviour in README and AGENTS guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855df44ef6c8325828dcd18402d4bcb