### PR TITLE
Refactor puzzle parsing helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,13 @@ whenever navigation logic needs the key code for moving backward.
 ## Clue Group Checker (2025)
 
 The helper method `checkClueGroup(selector, direction, starts)` updates clue list items by adding or removing the `complete` class based on whether their answer cells contain letters. `updateClueCompletion()` now delegates to this method for both across and down clues so they behave identically.
+
+## Puzzle Data Helpers (2025)
+
+Puzzle XML parsing is modularized into three helpers:
+
+- `parseGrid(doc)` builds the grid array from the `<grid>` and `<cell>` elements.
+- `parseClues(doc)` returns arrays for across and down clues.
+- `computeWordMetadata(grid)` computes starting positions and lengths for each word.
+
+`parsePuzzleData()` uses these helpers and still returns `{ width, height, grid, cluesAcross, cluesDown, acrossStarts, downStarts }`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See [COMPOSERS.md](COMPOSERS.md) for guidance on writing your own crossword file
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups
+- Puzzle data parsing split into helper functions (`parseGrid`, `parseClues`, `computeWordMetadata`) for readability
 - Clue enumerations shown using values from `social_deduction_ok.xml`
 - Responsive grid: cells scale with the viewport but never exceed 500&nbsp;px in total width; letter and clue number sizes scale with the cells
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again

--- a/main.js
+++ b/main.js
@@ -27,6 +27,93 @@ function getMoveBackDir(currentDirection) {
   return currentDirection === 'across' ? 'ArrowLeft' : 'ArrowUp';
 }
 
+function parseGrid(doc) {
+  const gridNode = doc.querySelector('grid');
+  const width = parseInt(gridNode.getAttribute('width'), 10);
+  const height = parseInt(gridNode.getAttribute('height'), 10);
+  const grid = Array.from({ length: height }, () => Array(width).fill(null));
+
+  doc.querySelectorAll('cell').forEach(cell => {
+    const x = parseInt(cell.getAttribute('x'), 10) - 1;
+    const y = parseInt(cell.getAttribute('y'), 10) - 1;
+    const type = cell.getAttribute('type');
+    if (type === 'block') {
+      grid[y][x] = { type: 'block' };
+    } else {
+      grid[y][x] = {
+        type: 'letter',
+        solution: cell.getAttribute('solution') || '',
+        number: cell.getAttribute('number') || ''
+      };
+    }
+  });
+
+  return { width, height, grid };
+}
+
+function parseClues(doc) {
+  const clueSections = doc.querySelectorAll('clues[ordering="normal"]');
+  const cluesAcross = [];
+  const cluesDown = [];
+  if (clueSections[0]) {
+    clueSections[0].querySelectorAll('clue').forEach(cl => {
+      cluesAcross.push({
+        number: cl.getAttribute('number'),
+        text: cl.textContent,
+        enumeration: cl.getAttribute('format') || ''
+      });
+    });
+  }
+  if (clueSections[1]) {
+    clueSections[1].querySelectorAll('clue').forEach(cl => {
+      cluesDown.push({
+        number: cl.getAttribute('number'),
+        text: cl.textContent,
+        enumeration: cl.getAttribute('format') || ''
+      });
+    });
+  }
+  return { cluesAcross, cluesDown };
+}
+
+function computeWordMetadata(grid) {
+  const height = grid.length;
+  const width = grid[0].length;
+  const acrossLengths = {};
+  const downLengths = {};
+  const acrossStarts = {};
+  const downStarts = {};
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const cell = grid[y][x];
+      if (!cell || cell.type === 'block' || !cell.number) continue;
+      if (x === 0 || grid[y][x - 1].type === 'block') {
+        let len = 0;
+        let cx = x;
+        while (cx < width && grid[y][cx].type !== 'block') {
+          len++;
+          cx++;
+        }
+        acrossLengths[cell.number] = len;
+        acrossStarts[cell.number] = { x, y };
+      }
+      if (y === 0 || grid[y - 1][x].type === 'block') {
+        let len = 0;
+        let cy = y;
+        while (cy < height && grid[cy][x].type !== 'block') {
+          len++;
+          cy++;
+        }
+        downLengths[cell.number] = len;
+        downStarts[cell.number] = { x, y };
+      }
+    }
+  }
+
+  return { acrossStarts, downStarts, acrossLengths, downLengths };
+}
+
 class Crossword {
   constructor(xmlData) {
     console.log('Crossword Viewer: Starting');
@@ -49,78 +136,14 @@ class Crossword {
     const parser = new DOMParser();
     const doc = parser.parseFromString(xmlString, 'text/xml');
 
-    const gridNode = doc.querySelector('grid');
-    const width = parseInt(gridNode.getAttribute('width'), 10);
-    const height = parseInt(gridNode.getAttribute('height'), 10);
-    const grid = Array.from({ length: height }, () => Array(width).fill(null));
-
-    doc.querySelectorAll('cell').forEach(cell => {
-      const x = parseInt(cell.getAttribute('x'), 10) - 1;
-      const y = parseInt(cell.getAttribute('y'), 10) - 1;
-      const type = cell.getAttribute('type');
-      if (type === 'block') {
-        grid[y][x] = { type: 'block' };
-      } else {
-        grid[y][x] = {
-          type: 'letter',
-          solution: cell.getAttribute('solution') || '',
-          number: cell.getAttribute('number') || ''
-        };
-      }
-    });
-
-    const clueSections = doc.querySelectorAll('clues[ordering="normal"]');
-    const cluesAcross = [];
-    const cluesDown = [];
-    if (clueSections[0]) {
-      clueSections[0].querySelectorAll('clue').forEach(cl => {
-        cluesAcross.push({
-          number: cl.getAttribute('number'),
-          text: cl.textContent,
-          enumeration: cl.getAttribute('format') || ''
-        });
-      });
-    }
-    if (clueSections[1]) {
-      clueSections[1].querySelectorAll('clue').forEach(cl => {
-        cluesDown.push({
-          number: cl.getAttribute('number'),
-          text: cl.textContent,
-          enumeration: cl.getAttribute('format') || ''
-        });
-      });
-    }
-
-    const acrossLengths = {};
-    const downLengths = {};
-    const acrossStarts = {};
-    const downStarts = {};
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const cell = grid[y][x];
-        if (!cell || cell.type === 'block' || !cell.number) continue;
-        if (x === 0 || grid[y][x - 1].type === 'block') {
-          let len = 0;
-          let cx = x;
-          while (cx < width && grid[y][cx].type !== 'block') {
-            len++;
-            cx++;
-          }
-          acrossLengths[cell.number] = len;
-          acrossStarts[cell.number] = { x, y };
-        }
-        if (y === 0 || grid[y - 1][x].type === 'block') {
-          let len = 0;
-          let cy = y;
-          while (cy < height && grid[cy][x].type !== 'block') {
-            len++;
-            cy++;
-          }
-          downLengths[cell.number] = len;
-          downStarts[cell.number] = { x, y };
-        }
-      }
-    }
+    const { width, height, grid } = parseGrid(doc);
+    const { cluesAcross, cluesDown } = parseClues(doc);
+    const {
+      acrossStarts,
+      downStarts,
+      acrossLengths,
+      downLengths
+    } = computeWordMetadata(grid);
 
     cluesAcross.forEach(cl => {
       cl.length = acrossLengths[cl.number] || 0;


### PR DESCRIPTION
## Summary
- modularize puzzle data parsing with `parseGrid`, `parseClues`, and `computeWordMetadata`
- document new helpers in `AGENTS.md`
- mention helper split in `README.md`

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685653fa18a88325ac3fadc12575bbd0