### PR TITLE
Refactor into puzzle-parser and crossword modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,13 @@
 
 This project displays an interactive crossword in modern JavaScript and HTML.
 Puzzle data is loaded from `social_deduction_ok.xml` at runtime and rendered by
-`main.js` (an ES module). Open `index.html` in a browser to run the viewer.
+`index.js` (an ES module). Open `index.html` in a browser to run the viewer.
 
+Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parser.js` handles XML parsing.
 ## Agent Tasks
 - Parse puzzle XML and build the grid and clues.
 - Maintain user input handling and diagnostic helpers.
-- Keep the code modular and readable. `main.js` exports a `crossword` instance
+- Keep the code modular and readable. `index.js` exports a `crossword` instance
   that exposes helper methods such as `testGridIsBuilt()` and
   `testCluesPresent()`.
 - Update this file when guidance changes and log notable updates in
@@ -17,7 +18,7 @@ Puzzle data is loaded from `social_deduction_ok.xml` at runtime and rendered by
 - Use modern ES6+ JavaScript and plain HTML/CSS.
 - No server-side code or external dependencies.
 - Add helpful console output for debugging. Enable verbose diagnostics by setting
-  `TEST_MODE` to `true` near the top of `main.js`.
+  `TEST_MODE` to `true` near the top of `index.js`.
 
 ## Design Notes
 - **DOM caching**: `buildGrid()` stores cell elements in
@@ -31,7 +32,7 @@ Puzzle data is loaded from `social_deduction_ok.xml` at runtime and rendered by
   clickable.
 - **Responsive sizing**: grid dimensions are calculated using the CSS variable
   `--cell-size` based on the viewport so the puzzle fits on mobile and desktop.
-- **Puzzle parsing**: `parsePuzzleData()` delegates to `parseGrid`, `parseClues`
+- **Puzzle parsing**: `parsePuzzle()` delegates to `parseGrid`, `parseClues`
   and `computeWordMetadata` helpers for clarity.
 
 ## Repository Practices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2025
 - Clue clicking removed to prevent accidental scrolling.
+- Refactored into modules: `crossword.js` for the class, `puzzle-parser.js` for XML parsing, and entry script renamed to `index.js`.
 - Font sizes scale relative to each cell.
 - Debug logging for check helpers when `TEST_MODE` is true.
 - Letters overwrite existing input and stray text nodes are removed.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Parse puzzle data from `social_deduction_ok.xml` and render an interactive cross
 ## Files
 
 - `index.html` — main page
-- `main.js` — JS logic (loaded as an ES module)
+- `index.js` — JS logic (loaded as an ES module)
+- `crossword.js` — Crossword class implementation
+- `puzzle-parser.js` — puzzle parsing utilities
 - `social_deduction_ok.xml` — puzzle data in XML format loaded at runtime via fetch
 
 ## Creating Your Own Puzzle
@@ -39,7 +41,7 @@ See [COMPOSERS.md](COMPOSERS.md) for guidance on writing your own crossword file
 
 Open `index.html` in a modern browser.
 
-`main.js` exports a `crossword` instance and also attaches it to `window.crossword` for debugging from the console.
+`index.js` exports a `crossword` instance and also attaches it to `window.crossword` for debugging from the console.
 
 Use the "Copy Share Link" button to copy a URL representing your current grid state.
 
@@ -57,7 +59,7 @@ When all letters for a clue are filled in the clue becomes faint and now shows a
 
 ## Testing
 
-To enable verbose diagnostic output while developing, open `main.js` and set the
+To enable verbose diagnostic output while developing, open `index.js` and set the
 `TEST_MODE` constant near the top of the file to `true`:
 
 ```js
@@ -66,7 +68,7 @@ const TEST_MODE = true;
 
 Reload `index.html` in your browser after making this change. Open the browser's
 developer tools console (usually with <kbd>F12</kbd> or via "Inspect" → "Console" )
-and run the helper functions provided by `main.js`:
+and run the helper functions provided by `index.js`:
 
 - `testGridIsBuilt()` — returns `true` if the grid has been created.
 - `testCluesPresent()` — returns `true` if clues are displayed.

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <ul></ul>
         </div>
     </div>
-    <script type="module" src="main.js"></script>
+    <script type="module" src="index.js"></script>
 </body>
 </html>
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,88 @@
+import Crossword, { TEST_MODE } from './crossword.js';
+
+export let crossword;
+
+function initCrossword(xmlData) {
+  crossword = new Crossword(xmlData);
+
+  crossword.directionButton = document.getElementById('toggle-direction');
+  if (crossword.directionButton) {
+    crossword.directionButton.addEventListener('click', () => crossword.toggleDirection());
+    crossword.updateDirectionButton();
+  }
+
+  const checkLetterBtn = document.getElementById('check-letter');
+  if (checkLetterBtn) {
+    checkLetterBtn.addEventListener('click', () => crossword.checkLetter());
+  }
+
+  const checkWordBtn = document.getElementById('check-word');
+  if (checkWordBtn) {
+    checkWordBtn.addEventListener('click', () => crossword.checkWord());
+  }
+
+  document.addEventListener('keydown', (e) => crossword.handleKeyDown(e));
+  document.addEventListener('input', (e) => crossword.handleInput(e));
+
+  crossword.buildGrid();
+  crossword.buildClues(crossword.puzzleData.cluesAcross, crossword.puzzleData.cluesDown);
+
+  const loadedFromURL = crossword.loadStateFromURL();
+  if (!loadedFromURL) {
+    crossword.loadStateFromLocalStorage();
+  }
+
+  const firstCell = crossword.findFirstLetterCell();
+  if (firstCell) {
+    crossword.selectCell(firstCell);
+  }
+
+  crossword.copyLinkButton = document.getElementById('copy-link');
+  if (crossword.copyLinkButton) {
+    crossword.copyLinkButton.addEventListener('click', () => {
+      const url = crossword.getShareableURL();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(() => {
+          crossword.copyLinkButton.textContent = 'Link Copied!';
+          setTimeout(() => crossword.copyLinkButton.textContent = 'Copy Share Link', 2000);
+        }).catch(err => console.error('Clipboard error', err));
+      } else {
+        console.warn('Clipboard API not available');
+      }
+    });
+  }
+
+  crossword.clearProgressButton = document.getElementById('clear-progress');
+  if (crossword.clearProgressButton) {
+    crossword.clearProgressButton.addEventListener('click', () => {
+      localStorage.removeItem('crosswordState');
+      crossword.applyGridState('');
+    });
+  }
+
+  if (TEST_MODE) {
+    crossword.cellEls.flat().forEach(cell => {
+      if (!cell) return;
+      ['pointerdown', 'pointerup', 'click'].forEach(ev =>
+        cell.addEventListener(ev, () =>
+          console.log(ev, cell.dataset.x, cell.dataset.y,
+            'active:', document.activeElement.id)));
+    });
+  }
+
+  console.log('Crossword Viewer: Ready');
+
+  window.testGridIsBuilt = crossword.testGridIsBuilt.bind(crossword);
+  window.testCluesPresent = crossword.testCluesPresent.bind(crossword);
+  window.logGridState = crossword.logGridState.bind(crossword);
+  window.getShareableURL = crossword.getShareableURL.bind(crossword);
+
+  window.crossword = crossword;
+}
+
+fetch('social_deduction_ok.xml')
+  .then(res => res.text())
+  .then(initCrossword)
+  .catch(err => console.error('Failed to load social_deduction_ok.xml', err));
+
+export { crossword as default };

--- a/puzzle-parser.js
+++ b/puzzle-parser.js
@@ -1,0 +1,113 @@
+// Puzzle parsing utilities
+
+function parseGrid(doc) {
+  const gridNode = doc.querySelector('grid');
+  const width = parseInt(gridNode.getAttribute('width'), 10);
+  const height = parseInt(gridNode.getAttribute('height'), 10);
+  const grid = Array.from({ length: height }, () => Array(width).fill(null));
+
+  doc.querySelectorAll('cell').forEach(cell => {
+    const x = parseInt(cell.getAttribute('x'), 10) - 1;
+    const y = parseInt(cell.getAttribute('y'), 10) - 1;
+    const type = cell.getAttribute('type');
+    if (type === 'block') {
+      grid[y][x] = { type: 'block' };
+    } else {
+      grid[y][x] = {
+        type: 'letter',
+        solution: cell.getAttribute('solution') || '',
+        number: cell.getAttribute('number') || ''
+      };
+    }
+  });
+
+  return { width, height, grid };
+}
+
+function parseClues(doc) {
+  const clueSections = doc.querySelectorAll('clues[ordering="normal"]');
+  const cluesAcross = [];
+  const cluesDown = [];
+  if (clueSections[0]) {
+    clueSections[0].querySelectorAll('clue').forEach(cl => {
+      cluesAcross.push({
+        number: cl.getAttribute('number'),
+        text: cl.textContent,
+        enumeration: cl.getAttribute('format') || ''
+      });
+    });
+  }
+  if (clueSections[1]) {
+    clueSections[1].querySelectorAll('clue').forEach(cl => {
+      cluesDown.push({
+        number: cl.getAttribute('number'),
+        text: cl.textContent,
+        enumeration: cl.getAttribute('format') || ''
+      });
+    });
+  }
+  return { cluesAcross, cluesDown };
+}
+
+function computeWordMetadata(grid) {
+  const height = grid.length;
+  const width = grid[0].length;
+  const acrossLengths = {};
+  const downLengths = {};
+  const acrossStarts = {};
+  const downStarts = {};
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const cell = grid[y][x];
+      if (!cell || cell.type === 'block' || !cell.number) continue;
+      if (x === 0 || grid[y][x - 1].type === 'block') {
+        let len = 0;
+        let cx = x;
+        while (cx < width && grid[y][cx].type !== 'block') {
+          len++;
+          cx++;
+        }
+        acrossLengths[cell.number] = len;
+        acrossStarts[cell.number] = { x, y };
+      }
+      if (y === 0 || grid[y - 1][x].type === 'block') {
+        let len = 0;
+        let cy = y;
+        while (cy < height && grid[cy][x].type !== 'block') {
+          len++;
+          cy++;
+        }
+        downLengths[cell.number] = len;
+        downStarts[cell.number] = { x, y };
+      }
+    }
+  }
+
+  return { acrossStarts, downStarts, acrossLengths, downLengths };
+}
+
+export function parsePuzzle(xmlString) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlString, 'text/xml');
+
+  const { width, height, grid } = parseGrid(doc);
+  const { cluesAcross, cluesDown } = parseClues(doc);
+  const {
+    acrossStarts,
+    downStarts,
+    acrossLengths,
+    downLengths
+  } = computeWordMetadata(grid);
+
+  cluesAcross.forEach(cl => {
+    cl.length = acrossLengths[cl.number] || 0;
+  });
+  cluesDown.forEach(cl => {
+    cl.length = downLengths[cl.number] || 0;
+  });
+
+  return { width, height, grid, cluesAcross, cluesDown, acrossStarts, downStarts };
+}
+
+export { parseGrid, parseClues, computeWordMetadata };


### PR DESCRIPTION
## Summary
- extract puzzle parsing helpers into `puzzle-parser.js`
- move `Crossword` class into new `crossword.js`
- streamline old `main.js` into `index.js`
- update HTML to load the new entry point
- document module split in README and CHANGELOG
- refresh agent guide with new filenames

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68565b0e0b3c83258502c0268d755dce