### PR TITLE
Add puzzle selection via URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # Agent Guide
 
 This project displays an interactive crossword in modern JavaScript and HTML.
-Puzzle data is loaded from `social_deduction_ok.xml` at runtime and rendered by
-`index.js` (an ES module). Open `index.html` in a browser to run the viewer.
+Puzzle data is loaded from an XML file specified via the `puzzle` URL parameter
+(default `social_deduction_ok.xml`) and rendered by `index.js` (an ES module).
+Open `index.html` in a browser to run the viewer.
 
 Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parser.js` handles XML parsing.
 ## Agent Tasks
@@ -37,6 +38,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - **State persistence**: progress is stored in `localStorage` under
   `crosswordState` and can be shared via URLs using `getShareableURL()`
   and `loadStateFromURL()`.
+- **Puzzle links**: `buildPuzzleLinks()` populates a list of available puzzles
+  from a static array of `{name, file}` objects. Links update the `puzzle`
+  query parameter.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   `getMoveBackDir`, `checkClueGroup`, and puzzle parsing helpers
   (`parseGrid`, `parseClues`, `computeWordMetadata`).
 - Puzzle file renamed to `social_deduction_ok.xml`.
+- Puzzle file can now be selected via `?puzzle=` parameter and
+  `buildPuzzleLinks()` populates a list of available puzzles.
 
 ## 2024
 - Keyboard input handled at the document level with `contenteditable`

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Crossword Viewer (Modern)
 
 This project builds an interactive crossword viewer in Javascript + HTML.
-The puzzle data lives in `social_deduction_ok.xml` and is fetched at runtime.
+By default it loads `social_deduction_ok.xml`, but you can specify a different
+puzzle via the `?puzzle=` URL parameter.
 
 See [CHANGELOG.md](CHANGELOG.md) for a summary of updates.
 
 ## Goal
 
-Parse puzzle data from `social_deduction_ok.xml` and render an interactive crossword grid and clues.
+Parse puzzle data from the XML file specified in the URL (default `social_deduction_ok.xml`) and render an interactive crossword grid and clues.
 
 ## Files
 
@@ -15,7 +16,7 @@ Parse puzzle data from `social_deduction_ok.xml` and render an interactive cross
 - `index.js` — JS logic (loaded as an ES module)
 - `crossword.js` — Crossword class implementation
 - `puzzle-parser.js` — puzzle parsing utilities
-- `social_deduction_ok.xml` — puzzle data in XML format loaded at runtime via fetch
+- `social_deduction_ok.xml` — example puzzle data file loaded by default via fetch
 
 ## Creating Your Own Puzzle
 
@@ -34,7 +35,7 @@ See [COMPOSERS.md](COMPOSERS.md) for guidance on writing your own crossword file
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups
 - Puzzle data parsing split into helper functions (`parseGrid`, `parseClues`, `computeWordMetadata`) for readability
-- Clue enumerations shown using values from `social_deduction_ok.xml`
+- Clue enumerations shown using values from the loaded puzzle file
 - Responsive grid: cells scale with the viewport but never exceed 500&nbsp;px in total width; letter and clue number sizes scale with the cells
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again
 

--- a/SETTERS.md
+++ b/SETTERS.md
@@ -112,11 +112,14 @@ Here is a simple 3x3 puzzle to demonstrate a complete file.
 
 ### Using Your Puzzle
 
-Once you have created your `.xml` file, save it in the project directory. To make the viewer load your puzzle, you must update the filename inside `main.js`:
+Once you have created your `.xml` file, save it in the project directory. The
+viewer loads `social_deduction_ok.xml` by default, but you can specify your file
+via the `?puzzle=` URL parameter or by editing the fetch call in `index.js`:
 
 ```javascript
-// In main.js, find this line and change the filename:
-fetch('your-puzzle-filename.xml')
+// In index.js, find this line and change the filename if you prefer a fixed file
+const puzzleFile = getPuzzleFileFromURL();
+fetch(puzzleFile)
   .then(res => res.text())
   // ...
 ```

--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
             <button id="copy-link">Copy Share Link</button>
             <button id="clear-progress">Clear Progress</button>
         </div>
+        <div id="puzzle-links">
+            <h3>Puzzles</h3>
+            <ul></ul>
+        </div>
         <div id="grid"></div>
     </div>
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,28 @@
 import Crossword, { TEST_MODE } from './crossword.js';
 
+const puzzles = [
+  { name: 'Social Deduction', file: 'social_deduction_ok.xml' }
+];
+
+function getPuzzleFileFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('puzzle') || 'social_deduction_ok.xml';
+}
+
+export function buildPuzzleLinks() {
+  const listEl = document.querySelector('#puzzle-links ul');
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  puzzles.forEach(p => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `?puzzle=${encodeURIComponent(p.file)}`;
+    a.textContent = p.name;
+    li.appendChild(a);
+    listEl.appendChild(li);
+  });
+}
+
 export let crossword;
 
 function initCrossword(xmlData) {
@@ -80,9 +103,12 @@ function initCrossword(xmlData) {
   window.crossword = crossword;
 }
 
-fetch('social_deduction_ok.xml')
+buildPuzzleLinks();
+
+const puzzleFile = getPuzzleFileFromURL();
+fetch(puzzleFile)
   .then(res => res.text())
   .then(initCrossword)
-  .catch(err => console.error('Failed to load social_deduction_ok.xml', err));
+  .catch(err => console.error('Failed to load', puzzleFile, err));
 
 export { crossword as default };

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,30 @@
             margin-bottom: 1em;
         }
 
+        #puzzle-links {
+            margin-bottom: 1em;
+        }
+
+        #puzzle-links ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+            display: flex;
+            gap: 0.5em;
+        }
+
+        #puzzle-links a {
+            text-decoration: none;
+            padding: 0.2em 0.5em;
+            background-color: #e6eaff;
+            border: 1px solid #888;
+            border-radius: 4px;
+        }
+
+        #puzzle-links a:hover {
+            background-color: #d4d8ff;
+        }
+
 
 
         #clues {


### PR DESCRIPTION
## Summary
- parse URL for `puzzle` parameter and use it when fetching puzzle data
- list available puzzles via new `buildPuzzleLinks()`
- style and add puzzle links section in the page
- update docs for the new behaviour

## Testing
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_685663bdf5208325a95a15af9eba15d5