### PR TITLE
Add puzzle list links after clues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   and `loadStateFromURL()`.
 - **Puzzle links**: `buildPuzzleLinks()` populates a list of available puzzles
   from a static array of `{name, file}` objects. Links update the `puzzle`
-  query parameter.
+  query parameter and are displayed in a list after the clues.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Puzzle file renamed to `social_deduction_ok.xml`.
 - Puzzle file can now be selected via `?puzzle=` parameter and
   `buildPuzzleLinks()` populates a list of available puzzles.
+- Puzzle links now appear after the clues and omit the current puzzle.
 
 ## 2024
 - Keyboard input handled at the document level with `contenteditable`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See [COMPOSERS.md](COMPOSERS.md) for guidance on writing your own crossword file
 - Shareable URLs for puzzle state
 - Progress saved to `localStorage` and restored on reload
 - Basic test functions
+- Links to other puzzles after the clues
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups

--- a/index.html
+++ b/index.html
@@ -16,10 +16,6 @@
             <button id="copy-link">Copy Share Link</button>
             <button id="clear-progress">Clear Progress</button>
         </div>
-        <div id="puzzle-links">
-            <h3>Puzzles</h3>
-            <ul></ul>
-        </div>
         <div id="grid"></div>
     </div>
 
@@ -33,6 +29,7 @@
             <ul></ul>
         </div>
     </div>
+    <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
     <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -10,10 +10,12 @@ function getPuzzleFileFromURL() {
 }
 
 export function buildPuzzleLinks() {
-  const listEl = document.querySelector('#puzzle-links ul');
+  const listEl = document.querySelector('#puzzle-links');
   if (!listEl) return;
   listEl.innerHTML = '';
+  const current = getPuzzleFileFromURL();
   puzzles.forEach(p => {
+    if (p.file === current) return;
     const li = document.createElement('li');
     const a = document.createElement('a');
     a.href = `?puzzle=${encodeURIComponent(p.file)}`;

--- a/styles.css
+++ b/styles.css
@@ -129,11 +129,11 @@
             margin-bottom: 1em;
         }
 
-        #puzzle-links {
-            margin-bottom: 1em;
+        #puzzle-list {
+            margin-top: 1em;
         }
 
-        #puzzle-links ul {
+        #puzzle-links {
             list-style: none;
             padding-left: 0;
             margin: 0;


### PR DESCRIPTION
## Summary
- move puzzle links below the clues
- style new `puzzle-list` container
- skip the current puzzle when building links
- document new placement of puzzle links

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_685664af0b38832583a5eb8eb78aeeb5