### PR TITLE
Fix puzzle list toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,10 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - **State persistence**: progress is stored in `localStorage` under
   `crosswordState` and can be shared via URLs using `getShareableURL()`
   and `loadStateFromURL()`.
-- **Puzzle links**: `buildPuzzleLinks()` populates a list of available puzzles
-  from a static array of `{name, file}` objects. Links update the `puzzle`
-  query parameter and are displayed in a list after the clues.
+- **Puzzle links**: `buildPuzzleLinks()` populates a list of all puzzles from a
+  static array of `{name, file}` objects. Links update the `puzzle` query
+  parameter. A "Show Puzzles" button toggles the list after the clues so it's
+  out of the way.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented in this file.
 - Puzzle file renamed to `social_deduction_ok.xml`.
 - Puzzle file can now be selected via `?puzzle=` parameter and
   `buildPuzzleLinks()` populates a list of available puzzles.
-- Puzzle links now appear after the clues and omit the current puzzle.
+- Puzzle links now appear after the clues.
+- "Show Puzzles" button toggles the list and the current puzzle is included.
 - Documented obsolete instruction about always loading
   `social_deduction_ok.xml`.
 - Keyboard input handled at the document level with `contenteditable`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Shareable URLs for puzzle state
 - Progress saved to `localStorage` and restored on reload
 - Basic test functions
-- Links to other puzzles after the clues
+- "Show Puzzles" button reveals links to all puzzles after the clues
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
             <ul></ul>
         </div>
     </div>
+    <button id="show-puzzles">Show Puzzles</button>
     <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
     <script type="module" src="index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -13,9 +13,7 @@ export function buildPuzzleLinks() {
   const listEl = document.querySelector('#puzzle-links');
   if (!listEl) return;
   listEl.innerHTML = '';
-  const current = getPuzzleFileFromURL();
   puzzles.forEach(p => {
-    if (p.file === current) return;
     const li = document.createElement('li');
     const a = document.createElement('a');
     a.href = `?puzzle=${encodeURIComponent(p.file)}`;
@@ -106,6 +104,16 @@ function initCrossword(xmlData) {
 }
 
 buildPuzzleLinks();
+
+const showPuzzlesBtn = document.getElementById('show-puzzles');
+const puzzleList = document.getElementById('puzzle-list');
+if (showPuzzlesBtn && puzzleList) {
+  showPuzzlesBtn.addEventListener('click', () => {
+    const visible = puzzleList.style.display === 'block';
+    puzzleList.style.display = visible ? 'none' : 'block';
+    showPuzzlesBtn.textContent = visible ? 'Show Puzzles' : 'Hide Puzzles';
+  });
+}
 
 const puzzleFile = getPuzzleFileFromURL();
 fetch(puzzleFile)

--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,11 @@
 
         #puzzle-list {
             margin-top: 1em;
+            display: none;
+        }
+
+        #show-puzzles {
+            margin-top: 1em;
         }
 
         #puzzle-links {


### PR DESCRIPTION
## Summary
- add `Show Puzzles` button after clues
- hide puzzle list by default and toggle it with the button
- always list all puzzles
- document puzzle toggle button in README and AGENTS guide
- note change in CHANGELOG

## Testing
- `node --check index.js`
- `node -e "const fs=require('fs');const {parsePuzzle}=require('./puzzle-parser.js');console.log(parsePuzzle(fs.readFileSync('social_deduction_ok.xml','utf-8')).grid.length);"` *(fails: DOMParser is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6856678b3ce48325b04f4fc82cc53ade