### PR TITLE
Add reveal options and remove clear progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   static array of `{name, file}` objects. Links update the `puzzle` query
   parameter. A "Show Puzzles" button toggles the list after the clues so it's
   out of the way.
+- **Reveal features**: `revealCurrentClue()` and `revealGrid()` fill in answers
+  after the user confirms via a custom overlay.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,6 @@ All notable changes to this project will be documented in this file.
 - Clue enumeration strings displayed.
 - Responsive grid sizing via CSS variable `--cell-size`.
 - Added "Check Letter" and "Check Word" buttons.
+- Removed "Clear Progress" button.
+- Added "Reveal Clue" and "Reveal Grid" buttons with confirmation overlay.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Clue enumerations shown using values from the loaded puzzle file
 - Responsive grid: cells scale with the viewport but never exceed 500&nbsp;px in total width; letter and clue number sizes scale with the cells
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again
+- "Reveal Clue" and "Reveal Grid" buttons fill answers after a confirmation prompt
 
 See [CHANGELOG.md](CHANGELOG.md) for a summary of updates.
 

--- a/crossword.js
+++ b/crossword.js
@@ -39,7 +39,6 @@ export default class Crossword {
     this.directionButton = null;
     this.feedbackCells = [];
     this.copyLinkButton = null;
-    this.clearProgressButton = null;
     this.cellEls = [];
     this.puzzleData = parsePuzzle(xmlData);
   }
@@ -548,6 +547,36 @@ export default class Crossword {
         this.feedbackCells.push(el);
       }
     });
+  }
+
+  revealCurrentClue() {
+    if (!this.selectedCell) return;
+    const cells = this.getWordCells(this.selectedCell, this.currentDirection);
+    cells.forEach(({ el, data }) => {
+      const letterEl = el.querySelector('.letter');
+      if (letterEl) {
+        letterEl.textContent = (data.solution || '').toUpperCase();
+      }
+    });
+    this.saveStateToLocalStorage();
+    this.updateClueCompletion();
+  }
+
+  revealGrid() {
+    for (let y = 0; y < this.puzzleData.height; y++) {
+      for (let x = 0; x < this.puzzleData.width; x++) {
+        const data = this.puzzleData.grid[y][x];
+        if (data.type === 'letter') {
+          const el = this.cellEls[y][x];
+          const letterEl = el.querySelector('.letter');
+          if (letterEl) {
+            letterEl.textContent = (data.solution || '').toUpperCase();
+          }
+        }
+      }
+    }
+    this.saveStateToLocalStorage();
+    this.updateClueCompletion();
   }
 
   checkClueGroup(selector, direction, starts) {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
             <button id="check-letter">Check Letter</button>
             <button id="check-word">Check Word</button>
             <button id="copy-link">Copy Share Link</button>
-            <button id="clear-progress">Clear Progress</button>
+            <button id="reveal-clue">Reveal Clue</button>
+            <button id="reveal-grid">Reveal Grid</button>
         </div>
         <div id="grid"></div>
     </div>
@@ -31,6 +32,13 @@
     </div>
     <button id="show-puzzles">Show Puzzles</button>
     <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
+    <div id="confirm-overlay">
+        <div id="confirm-box">
+            <p id="confirm-message"></p>
+            <button id="confirm-yes">Yes</button>
+            <button id="confirm-no">Cancel</button>
+        </div>
+    </div>
     <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -24,6 +24,37 @@ export function buildPuzzleLinks() {
 }
 
 export let crossword;
+const confirmOverlay = document.getElementById('confirm-overlay');
+const confirmMessage = document.getElementById('confirm-message');
+const confirmYes = document.getElementById('confirm-yes');
+const confirmNo = document.getElementById('confirm-no');
+let confirmCallback = null;
+
+function showConfirm(message, cb) {
+  confirmMessage.textContent = message;
+  confirmCallback = cb;
+  if (confirmOverlay) {
+    confirmOverlay.style.display = 'flex';
+  }
+}
+
+function hideConfirm() {
+  if (confirmOverlay) {
+    confirmOverlay.style.display = 'none';
+  }
+  confirmCallback = null;
+}
+
+if (confirmYes) {
+  confirmYes.addEventListener('click', () => {
+    if (confirmCallback) confirmCallback();
+    hideConfirm();
+  });
+}
+
+if (confirmNo) {
+  confirmNo.addEventListener('click', hideConfirm);
+}
 
 function initCrossword(xmlData) {
   crossword = new Crossword(xmlData);
@@ -75,11 +106,17 @@ function initCrossword(xmlData) {
     });
   }
 
-  crossword.clearProgressButton = document.getElementById('clear-progress');
-  if (crossword.clearProgressButton) {
-    crossword.clearProgressButton.addEventListener('click', () => {
-      localStorage.removeItem('crosswordState');
-      crossword.applyGridState('');
+  const revealClueBtn = document.getElementById('reveal-clue');
+  if (revealClueBtn) {
+    revealClueBtn.addEventListener('click', () => {
+      showConfirm('Reveal the answer for this clue?', () => crossword.revealCurrentClue());
+    });
+  }
+
+  const revealGridBtn = document.getElementById('reveal-grid');
+  if (revealGridBtn) {
+    revealGridBtn.addEventListener('click', () => {
+      showConfirm('Reveal the entire grid?', () => crossword.revealGrid());
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,31 @@
             display: none;
         }
 
+        #confirm-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        #confirm-box {
+            background-color: #fff;
+            padding: 1em;
+            border-radius: 8px;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+            text-align: center;
+        }
+
+        #confirm-box p {
+            margin-bottom: 1em;
+        }
+
         #show-puzzles {
             margin-top: 1em;
         }


### PR DESCRIPTION
## Summary
- add new `Reveal Clue` and `Reveal Grid` buttons
- add confirmation overlay for reveal actions
- implement `revealCurrentClue` and `revealGrid`
- drop unused Clear Progress button
- document reveal features

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685669ef06f08325a7498fd301a97a6c