### PR TITLE
Adjust puzzle list button layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   and `loadStateFromURL()`.
 - **Puzzle links**: `buildPuzzleLinks()` populates a list of all puzzles from a
   static array of `{name, file}` objects. Links update the `puzzle` query
-  parameter. A "Show Puzzles" button toggles the list after the clues so it's
-  out of the way.
+  parameter. A "Show all available crosswords" button toggles the list after the
+  clues on mobile, and sits below the grid and clues on wider screens.
 - **Reveal features**: `revealCurrentClue()` and `revealGrid()` fill in answers
   after the user confirms via a custom overlay.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file.
 - Puzzle file can now be selected via `?puzzle=` parameter and
   `buildPuzzleLinks()` populates a list of available puzzles.
 - Puzzle links now appear after the clues.
-- "Show Puzzles" button toggles the list and the current puzzle is included.
+- "Show all available crosswords" button toggles the puzzle list and now sits
+  below the grid and clues on desktop.
 - Documented obsolete instruction about always loading
   `social_deduction_ok.xml`.
 - Keyboard input handled at the document level with `contenteditable`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Shareable URLs for puzzle state
 - Progress saved to `localStorage` and restored on reload
 - Basic test functions
-- "Show Puzzles" button reveals links to all puzzles after the clues
+- "Show all available crosswords" button reveals a puzzle list after the clues 
+  (desktop layout places the button below the grid and clues)
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             <ul></ul>
         </div>
     </div>
-    <button id="show-puzzles">Show Puzzles</button>
+    <button id="show-puzzles">Show all available crosswords</button>
     <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
     <div id="confirm-overlay">
         <div id="confirm-box">

--- a/index.js
+++ b/index.js
@@ -148,7 +148,8 @@ if (showPuzzlesBtn && puzzleList) {
   showPuzzlesBtn.addEventListener('click', () => {
     const visible = puzzleList.style.display === 'block';
     puzzleList.style.display = visible ? 'none' : 'block';
-    showPuzzlesBtn.textContent = visible ? 'Show Puzzles' : 'Hide Puzzles';
+    showPuzzlesBtn.textContent = visible ?
+      'Show all available crosswords' : 'Hide crosswords';
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@
             margin: 2rem;
             display: flex;
             flex-direction: row;
+            flex-wrap: wrap;
+            align-items: flex-start;
             gap: 2rem;
             background-color: #eef6ff; /* pastel blue background */
         }
@@ -161,6 +163,8 @@
 
         #show-puzzles {
             margin-top: 1em;
+            flex-basis: 100%;
+            align-self: flex-start;
         }
 
         #puzzle-links {


### PR DESCRIPTION
## Summary
- rename puzzle toggle button to "Show all available crosswords"
- position the button below the grid and clues on wide screens
- update docs and agent guide

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68566bf024ac832596da6d6b9b4b02f3