### PR TITLE
Fix crossword button layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - Puzzle links now appear after the clues.
 - "Show all available crosswords" button toggles the puzzle list and now sits
   below the grid and clues on desktop.
+- Fixed layout so the button actually displays below the crossword on wider
+  screens.
 - Documented obsolete instruction about always loading
   `social_deduction_ok.xml`.
 - Keyboard input handled at the document level with `contenteditable`

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Shareable URLs for puzzle state
 - Progress saved to `localStorage` and restored on reload
 - Basic test functions
-- "Show all available crosswords" button reveals a puzzle list after the clues 
-  (desktop layout places the button below the grid and clues)
+- "Show all available crosswords" button reveals a puzzle list after the clues
+  and now spans the full width below the grid and clues on larger screens
 - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups

--- a/styles.css
+++ b/styles.css
@@ -131,10 +131,6 @@
             margin-bottom: 1em;
         }
 
-        #puzzle-list {
-            margin-top: 1em;
-            display: none;
-        }
 
         #confirm-overlay {
             position: fixed;
@@ -164,6 +160,13 @@
         #show-puzzles {
             margin-top: 1em;
             align-self: flex-start;
+            width: 100%;
+        }
+
+        #puzzle-list {
+            margin-top: 1em;
+            display: none;
+            width: 100%;
         }
 
         #puzzle-links {
@@ -212,9 +215,6 @@
             }
             #grid {
                 margin-bottom: 1rem;
-            }
-            #show-puzzles {
-                width: 100%;
             }
         }
 


### PR DESCRIPTION
## Summary
- keep the "Show all available crosswords" button and list full width
- document button placement in README
- note layout fix in CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68566ffba76483259d7880fb07aad03c