### PR TITLE
Add author metadata support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   clues on mobile, and sits below the grid and clues on wider screens.
 - **Reveal features**: `revealCurrentClue()` and `revealGrid()` fill in answers
   after the user confirms via a custom overlay.
+- **Author metadata**: `parsePuzzle()` now reads `<creator>` or `<author>` from
+  the puzzle file's `<metadata>` section and returns it as `author`. `index.js`
+  writes this value into the `#puzzle-author` element if present.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Basic test functions
 - "Show all available crosswords" button reveals a puzzle list below the clues
   and remains left-aligned rather than spanning the full width on larger screens
-- Diagnostic output in console
+- Displays the puzzle author's name if provided
+  - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups
 - Puzzle data parsing split into helper functions (`parseGrid`, `parseClues`, `computeWordMetadata`) for readability

--- a/SETTERS.md
+++ b/SETTERS.md
@@ -11,8 +11,29 @@ The entire puzzle should be wrapped in `<rectangular-puzzle>` and `<crossword>` 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
+  <metadata>
+    <creator>OkeyDoke</creator>
+  </metadata>
   <crossword>
     </crossword>
+</rectangular-puzzle>
+```
+
+### Metadata
+
+Optionally include a `<metadata>` block before the `<crossword>` element.
+Provide a `<creator>` or `<author>` tag with the setter's preferred name.
+The viewer displays whichever value is found.
+
+```xml
+<rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
+  <metadata>
+    <creator>OkeyDoke</creator>
+    <author>OkeyDoke</author>
+  </metadata>
+  <crossword>
+    ...
+  </crossword>
 </rectangular-puzzle>
 ```
 
@@ -82,6 +103,9 @@ Here is a simple 3x3 puzzle to demonstrate a complete file.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
+  <metadata>
+    <creator>OkeyDoke</creator>
+  </metadata>
   <crossword>
     <grid width="3" height="3">
       <cell x="1" y="1" solution="C" number="1"/>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     </div>
     <button id="show-puzzles">Show all available crosswords</button>
     <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
+    <p id="puzzle-author" class="puzzle-meta"></p>
     <div id="confirm-overlay">
         <div id="confirm-box">
             <p id="confirm-message"></p>

--- a/index.js
+++ b/index.js
@@ -76,6 +76,11 @@ function initCrossword(xmlData) {
   crossword.buildGrid();
   crossword.buildClues(crossword.puzzleData.cluesAcross, crossword.puzzleData.cluesDown);
 
+  const authorEl = document.getElementById('puzzle-author');
+  if (authorEl && crossword.puzzleData.author) {
+    authorEl.textContent = 'Author: ' + crossword.puzzleData.author;
+  }
+
   const loadedFromURL = crossword.loadStateFromURL();
   if (!loadedFromURL) {
     crossword.loadStateFromLocalStorage();

--- a/puzzle-parser.js
+++ b/puzzle-parser.js
@@ -91,6 +91,15 @@ export function parsePuzzle(xmlString) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(xmlString, 'text/xml');
 
+  const meta = doc.querySelector('metadata');
+  let author = '';
+  if (meta) {
+    const authorNode = meta.querySelector('author');
+    const creatorNode = meta.querySelector('creator');
+    author = (authorNode && authorNode.textContent) ||
+             (creatorNode && creatorNode.textContent) || '';
+  }
+
   const { width, height, grid } = parseGrid(doc);
   const { cluesAcross, cluesDown } = parseClues(doc);
   const {
@@ -107,7 +116,7 @@ export function parsePuzzle(xmlString) {
     cl.length = downLengths[cl.number] || 0;
   });
 
-  return { width, height, grid, cluesAcross, cluesDown, acrossStarts, downStarts };
+  return { width, height, grid, cluesAcross, cluesDown, acrossStarts, downStarts, author };
 }
 
 export { parseGrid, parseClues, computeWordMetadata };

--- a/social_deduction_ok.xml
+++ b/social_deduction_ok.xml
@@ -13,7 +13,8 @@
   <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle" alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ">
     <metadata>
       <title/>
-      <creator/>
+      <creator>OkeyDoke</creator>
+      <author>OkeyDoke</author>
       <copyright/>
       <description/>
     </metadata>

--- a/styles.css
+++ b/styles.css
@@ -189,6 +189,12 @@
             background-color: #d4d8ff;
         }
 
+        .puzzle-meta {
+            font-size: 0.8em;
+            color: #444;
+            margin-top: 0.5em;
+        }
+
 
 
         #clues {


### PR DESCRIPTION
## Summary
- support creator/author metadata when parsing puzzles
- expose author via new `#puzzle-author` area on the page
- document metadata syntax and author display in SETTERS guide and README
- note new metadata behaviour in AGENTS guide
- style author text subtly
- populate example crossword metadata with the handle "OkeyDoke"

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68567519b3dc83259a6314f04ff1034b