### PR TITLE
Update credits display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,11 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   clues on mobile, and sits below the grid and clues on wider screens.
 - **Reveal features**: `revealCurrentClue()` and `revealGrid()` fill in answers
   after the user confirms via a custom overlay.
-- **Author metadata**: `parsePuzzle()` now reads `<creator>` or `<author>` from
-  the puzzle file's `<metadata>` section and returns it as `author`. `index.js`
-  writes this value into the `#puzzle-author` element if present.
+ - **Author metadata**: `parsePuzzle()` reads `<creator>` or `<author>` from the
+   puzzle file's `<metadata>` section and returns it as `author`. `index.js`
+   shows "Crossword by ..." in the `#puzzle-author` element when a name is
+   provided and hides the element if none is found. The page always displays
+   "Page by Niall Cardin" using the `#page-credit` element.
 
 ## Repository Practices
 - Keep `AGENTS.md` concise; do not record a running change log here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,6 @@ All notable changes to this project will be documented in this file.
 - Added "Check Letter" and "Check Word" buttons.
 - Removed "Clear Progress" button.
 - Added "Reveal Clue" and "Reveal Grid" buttons with confirmation overlay.
+- Credits now show "Page by Niall Cardin" and hide the crossword author line
+  when no author is provided.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Basic test functions
 - "Show all available crosswords" button reveals a puzzle list below the clues
   and remains left-aligned rather than spanning the full width on larger screens
-- Displays the puzzle author's name if provided
+- Credits the page author (Niall Cardin) and shows the crossword author's name if provided
   - Diagnostic output in console
 - No server required — runs as static HTML/JS
 - Cells cached in memory for faster lookups

--- a/SETTERS.md
+++ b/SETTERS.md
@@ -12,7 +12,7 @@ The entire puzzle should be wrapped in `<rectangular-puzzle>` and `<crossword>` 
 <?xml version="1.0" encoding="UTF-8"?>
 <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
   <metadata>
-    <creator>OkeyDoke</creator>
+    <creator>AuthorName</creator>
   </metadata>
   <crossword>
     </crossword>
@@ -28,8 +28,8 @@ The viewer displays whichever value is found.
 ```xml
 <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
   <metadata>
-    <creator>OkeyDoke</creator>
-    <author>OkeyDoke</author>
+    <creator>AuthorName</creator>
+    <author>AuthorName</author>
   </metadata>
   <crossword>
     ...
@@ -104,7 +104,7 @@ Here is a simple 3x3 puzzle to demonstrate a complete file.
 <?xml version="1.0" encoding="UTF-8"?>
 <rectangular-puzzle xmlns="http://crossword.info/xml/rectangular-puzzle">
   <metadata>
-    <creator>OkeyDoke</creator>
+    <creator>AuthorName</creator>
   </metadata>
   <crossword>
     <grid width="3" height="3">

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <button id="show-puzzles">Show all available crosswords</button>
     <div id="puzzle-list"><ul id="puzzle-links"></ul></div>
     <p id="puzzle-author" class="puzzle-meta"></p>
+    <p id="page-credit" class="puzzle-meta">Page by Niall Cardin</p>
     <div id="confirm-overlay">
         <div id="confirm-box">
             <p id="confirm-message"></p>

--- a/index.js
+++ b/index.js
@@ -77,8 +77,13 @@ function initCrossword(xmlData) {
   crossword.buildClues(crossword.puzzleData.cluesAcross, crossword.puzzleData.cluesDown);
 
   const authorEl = document.getElementById('puzzle-author');
-  if (authorEl && crossword.puzzleData.author) {
-    authorEl.textContent = 'Author: ' + crossword.puzzleData.author;
+  if (authorEl) {
+    if (crossword.puzzleData.author) {
+      authorEl.textContent = 'Crossword by ' + crossword.puzzleData.author;
+      authorEl.style.display = 'block';
+    } else {
+      authorEl.style.display = 'none';
+    }
   }
 
   const loadedFromURL = crossword.loadStateFromURL();


### PR DESCRIPTION
## Summary
- show "Crossword by" text and hide author line if missing
- add page credit to index.html
- document behaviour in README and AGENTS
- use `AuthorName` in SETTERS example
- note credit change in CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68567c9e2df88325b4f9655311d03b84