### PR TITLE
Improve mobile beforeinput handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - **DOM caching**: `buildGrid()` stores cell elements in
   `crossword.cellEls[y][x]` for quick access.
 - **Input handling**: keyboard events are attached at the document level while
-  each grid cell is `contenteditable` so mobile keyboards work. `keydown` events
-  call `preventDefault()` to avoid duplicate letters and `input` events handle
-  mobile browsers.
+    each grid cell is `contenteditable` so mobile keyboards work. `keydown` events
+    call `preventDefault()` to avoid duplicate letters. `beforeinput` and `input`
+    events update letters on mobile without leaving stray DOM nodes.
 - **Completed clues**: the viewer adds the `complete` class when a clue is fully
   answered. Completed clues are styled faint with a strike-through and are not
   clickable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,7 @@ All notable changes to this project will be documented in this file.
 - Added "Reveal Clue" and "Reveal Grid" buttons with confirmation overlay.
 - Credits now show "Page by Niall C" and hide the crossword author line
   when no author is provided.
+- Input handling improved for mobile: a `beforeinput` listener now
+  prevents stray nodes and ensures `autoAdvance()` works with
+  on-screen keyboards.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 
 ### Input handling
 
-Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are handled at the document level: `keydown` covers desktop input while `input` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
+Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while `input` and `beforeinput` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice, and `beforeinput` prevents stray DOM changes when using mobile keyboards.
 
 ### Clue clicking
 

--- a/crossword.js
+++ b/crossword.js
@@ -394,6 +394,33 @@ export default class Crossword {
     }
   }
 
+  handleBeforeInput(e) {
+    const cell = e.target.closest('.cell');
+    if (!cell || cell.classList.contains('block')) return;
+    e.preventDefault();
+    if (cell !== this.selectedCell) {
+      this.selectCell(cell);
+    }
+
+    if (e.inputType && e.inputType.startsWith('delete')) {
+      this.clearFeedback();
+      this.handleBackspace();
+      return;
+    }
+
+    let letter = e.data;
+    if (!letter) return;
+    letter = letter.slice(-1);
+    if (/^[a-zA-Z]$/.test(letter)) {
+      this.clearFeedback();
+      removeTextNodes(cell);
+      cell.style.color = '';
+      this.setCellLetter(cell, letter);
+      this.autoAdvance();
+      this.saveStateToLocalStorage();
+    }
+  }
+
   handleBackspace() {
     if (!this.selectedCell) return;
     const letterEl = this.selectedCell.querySelector('.letter');

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function initCrossword(xmlData) {
   }
 
   document.addEventListener('keydown', (e) => crossword.handleKeyDown(e));
+  document.addEventListener('beforeinput', (e) => crossword.handleBeforeInput(e));
   document.addEventListener('input', (e) => crossword.handleInput(e));
 
   crossword.buildGrid();


### PR DESCRIPTION
## Summary
- add `beforeinput` support in Crossword class to handle mobile keyboards
- wire up the new listener in `index.js`
- document the new event handling in README and AGENTS
- log the update in CHANGELOG

## Testing
- `node -c index.js`
- `node -c crossword.js`


------
https://chatgpt.com/codex/tasks/task_e_6856851273408325828238f523eb4f63