### PR TITLE
Allow text selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
     each grid cell is `contenteditable` so mobile keyboards work. `keydown` events
     call `preventDefault()` to avoid duplicate letters. `beforeinput` and `input`
     events update letters on mobile without leaving stray DOM nodes.
+ - **Cell selection**: `.cell` elements now allow text selection (`user-select:
+   text`) which avoids overwriting issues while keeping the caret hidden via
+   `caret-color: transparent`.
 - **Completed clues**: the viewer adds the `complete` class when a clue is fully
   answered. Completed clues are styled faint with a strike-through and are not
   clickable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ All notable changes to this project will be documented in this file.
   prevents stray nodes and ensures `autoAdvance()` works with
   on-screen keyboards.
 
+- Cells allow text selection to avoid overwrite issues.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 ### Input handling
 
 Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while `input` and `beforeinput` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice, and `beforeinput` prevents stray DOM changes when using mobile keyboards.
+Cells may be selected normally so you can highlight a letter before typing to replace it.
 
 ### Clue clicking
 

--- a/styles.css
+++ b/styles.css
@@ -32,9 +32,9 @@
             line-height: var(--cell-size);
             cursor: pointer;
             position: relative;
-            /* avoid double events and accidental text selection on mobile */
+            /* avoid double events on mobile; allow text selection */
             touch-action: manipulation;
-            user-select: none;
+            user-select: text;
             caret-color: transparent;
         }
 


### PR DESCRIPTION
## Summary
- allow selection within cells so overwriting works as expected
- document cell selection behavior
- note the change in AGENTS guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68568de9af8c8325959230490de86776