### PR TITLE
Hide debug HTML behind TEST_MODE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - No server-side code or external dependencies.
 - Add helpful console output for debugging. Enable verbose diagnostics by setting
   `TEST_MODE` to `true` near the top of `index.js`.
+  When enabled, `crossword.js` creates a `<pre id="debug-log">` element and
+  appends it to the page to record debug messages.
 
 ## Design Notes
 - **DOM caching**: `buildGrid()` stores cell elements in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ All notable changes to this project will be documented in this file.
   on-screen keyboards.
 
 - Cells allow text selection to avoid overwrite issues.
+- Debug log element created only when `TEST_MODE` is true.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ and run the helper functions provided by `index.js`:
 - When `TEST_MODE` is enabled, the check buttons log detailed information about
   each cell they evaluate. Use the console logs to understand why a letter was
   flagged (or not) by the check.
+- When `TEST_MODE` is enabled, a debug log appears at the bottom of the page
+  showing internal events from `crossword.js`.
 
 ## Share Link Format
 

--- a/crossword.js
+++ b/crossword.js
@@ -41,17 +41,27 @@ export default class Crossword {
     this.copyLinkButton = null;
     this.cellEls = [];
     this.puzzleData = parsePuzzle(xmlData);
-    this.debugEl = document.getElementById('debug-log');
-    this.debugLog('Crossword Initialized (v1.2). Logging is active.');
+    if (TEST_MODE) {
+      this.debugEl = document.createElement('pre');
+      this.debugEl.id = 'debug-log';
+      this.debugEl.style.width = '100%';
+      this.debugEl.style.height = '200px';
+      this.debugEl.style.overflowY = 'scroll';
+      this.debugEl.style.border = '1px solid #ccc';
+      this.debugEl.style.backgroundColor = '#f0f0f0';
+      this.debugEl.style.padding = '5px';
+      this.debugEl.style.fontSize = '10px';
+      document.body.appendChild(this.debugEl);
+      this.debugLog('Crossword Initialized (v1.2). Logging is active.');
+    } else {
+      this.debugEl = null;
+    }
   }
 
   debugLog(message) {
-    // Only log if test mode is enabled.
-    if (!TEST_MODE) {
-      if (this.debugEl) this.debugEl.style.display = 'none';
+    if (!TEST_MODE || !this.debugEl) {
       return;
     }
-    if (!this.debugEl) return;
 
     const timestamp = new Date().toLocaleTimeString();
     const newLog = `[${timestamp}] ${message}`;

--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
             <button id="confirm-no">Cancel</button>
         </div>
     </div>
-    <pre id="debug-log" style="width: 100%; height: 200px; overflow-y: scroll; border: 1px solid #ccc; background-color: #f0f0f0; padding: 5px; font-size: 10px;"></pre>
     <script type="module" src="index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create the debug log element only when `TEST_MODE` is enabled
- document this behaviour in `AGENTS.md`, `CHANGELOG.md`, and `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857038ade448325bbef51ff5afec2f7