### PR TITLE
Fix grid cells painted black

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   `--cell-size` based on the viewport so the puzzle fits on mobile and desktop.
 - **Grid lines**: `#grid` uses a 1px `gap` on a black background with borderless
   cells so the dividing lines appear as thin black separators between squares.
+  Cells have a white background so the black grid lines don't obscure the grid.
 - **Puzzle parsing**: `parsePuzzle()` delegates to `parseGrid`, `parseClues`
   and `computeWordMetadata` helpers for clarity.
 - **State persistence**: progress is stored in `localStorage` under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ All notable changes to this project will be documented in this file.
 
 - Cells allow text selection to avoid overwrite issues.
 - Debug log element created only when `TEST_MODE` is true.
+- Cells now default to a white background so 1px black grid lines show correctly

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - No server required — runs as static HTML/JS
 - Clue enumerations shown using values from the loaded puzzle file
 - Responsive grid: cells scale with the viewport but never exceed 500&nbsp;px in total width; letter and clue number sizes scale with the cells
+- Thin black lines separate each cell using a 1px grid gap
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again
 - "Reveal Word" and "Reveal Grid" buttons fill answers after a confirmation prompt
 

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,7 @@
         .cell {
             width: var(--cell-size);
             height: var(--cell-size);
+            background-color: #fff;
             border: none;
             text-align: center;
             vertical-align: middle;


### PR DESCRIPTION
## Summary
- default `.cell` background to white so black background only paints dividing lines
- note cell background requirement in `AGENTS.md`
- mention thin grid lines in README features
- document fix in CHANGELOG

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68570ac08bb08325a0ddbb753b6d92bb