### PR TITLE
Refine agent docs and remove dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - Use modern ES6+ JavaScript and plain HTML/CSS.
 - No server-side code or external dependencies.
 - Add helpful console output for debugging. Enable verbose diagnostics by setting
-  `TEST_MODE` to `true` near the top of `index.js`.
+  `TEST_MODE` to `true` near the top of `crossword.js`.
   When enabled, `crossword.js` creates a `<pre id="debug-log">` element and
   appends it to the page to record debug messages.
 
@@ -28,8 +28,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
   `crossword.cellEls[y][x]` for quick access.
 - **Input handling**: keyboard events are attached at the document level while
     each grid cell is `contenteditable` so mobile keyboards work. `keydown` events
-    call `preventDefault()` to avoid duplicate letters. `beforeinput` and `input`
-    events update letters on mobile without leaving stray DOM nodes.
+    call `preventDefault()` to avoid duplicate letters. Each cell listens for the
+    `input` event so mobile browsers update letters correctly without leaving stray
+    DOM nodes.
  - **Cell selection**: `.cell` elements now allow text selection (`user-select:
    text`) which avoids overwriting issues while keeping the caret hidden via
    `caret-color: transparent`.
@@ -59,8 +60,8 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
    "Page by Niall C" using the `#page-credit` element.
 
 ## Repository Practices
-- Keep `AGENTS.md` concise; do not record a running change log here.
-  Use `CHANGELOG.md` for notable updates.
+- Keep `AGENTS.md` concise. Only record guidance that future agents must know.
+  Use `CHANGELOG.md` for notable updates instead of documenting minor tweaks.
 - Remove any obsolete sections once the related code is gone.
 - Run the simple browser-based tests when relevant:
   - `testGridIsBuilt()`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 
 ### Input handling
 
-Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while `input` and `beforeinput` events ensure mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice, and `beforeinput` prevents stray DOM changes when using mobile keyboards.
+Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while each cell listens for the `input` event so mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
 Cells may be selected normally so you can highlight a letter before typing to replace it.
 
 ### Clue clicking
@@ -59,7 +59,7 @@ When all letters for a clue are filled in the clue becomes faint and now shows a
 
 ## Testing
 
-To enable verbose diagnostic output while developing, open `index.js` and set the
+To enable verbose diagnostic output while developing, open `crossword.js` and set the
 `TEST_MODE` constant near the top of the file to `true`:
 
 ```js

--- a/crossword.js
+++ b/crossword.js
@@ -36,7 +36,6 @@ export default class Crossword {
     this.selectedCell = null;
     this.highlightedCells = [];
     this.currentDirection = 'across';
-    this.directionButton = null;
     this.feedbackCells = [];
     this.copyLinkButton = null;
     this.cellEls = [];
@@ -176,8 +175,6 @@ export default class Crossword {
     }
   }
 
-  // The rest of the functions are unchanged.
-  // ... [buildGrid, buildClues, selectCell, etc.]
 
   buildGrid() {
     console.log('Building grid...');
@@ -256,7 +253,6 @@ export default class Crossword {
     if (this.selectedCell === cell) {
       this.currentDirection = this.currentDirection === 'across' ? 'down' : 'across';
       this.highlightWord(cell);
-      this.updateDirectionButton();
       return;
     }
 
@@ -272,7 +268,6 @@ export default class Crossword {
       if (otherCells.length > cells.length) {
         this.currentDirection = other;
         cells = otherCells;
-        this.updateDirectionButton();
       }
     }
     this.highlightWord(this.selectedCell);
@@ -340,7 +335,6 @@ export default class Crossword {
     if (!moved) {
       this.debugLog('autoAdvance: Could not move in current direction. Toggling direction.');
       this.currentDirection = this.currentDirection === 'across' ? 'down' : 'across';
-      this.updateDirectionButton();
       this.moveSelection(getArrowForDirection(this.currentDirection, true));
     }
   }
@@ -661,22 +655,8 @@ export default class Crossword {
     const cell = this.cellEls[pos.y] && this.cellEls[pos.y][pos.x];
     if (cell) {
       this.currentDirection = direction;
-      this.updateDirectionButton();
       this.selectCell(cell, false);
     }
   }
 
-  updateDirectionButton() {
-    if (this.directionButton) {
-      this.directionButton.textContent = 'Mode: ' + (this.currentDirection === 'across' ? 'Across' : 'Down');
-    }
-  }
-
-  toggleDirection() {
-    this.currentDirection = this.currentDirection === 'across' ? 'down' : 'across';
-    this.updateDirectionButton();
-    if (this.selectedCell) {
-      this.highlightWord(this.selectedCell);
-    }
-  }
 }

--- a/index.js
+++ b/index.js
@@ -71,8 +71,6 @@ function initCrossword(xmlData) {
   }
 
   document.addEventListener('keydown', (e) => crossword.handleKeyDown(e));
-  // document.addEventListener('beforeinput', (e) => crossword.handleBeforeInput(e));
-  // document.addEventListener('input', (e) => crossword.handleInput(e));
 
   crossword.buildGrid();
   crossword.buildClues(crossword.puzzleData.cluesAcross, crossword.puzzleData.cluesDown);


### PR DESCRIPTION
## Summary
- correct TEST_MODE docs in AGENTS and README
- explain input events without mentioning beforeinput
- state that AGENTS.md should only track important guidance
- remove unused direction button code from crossword.js and leftover comment
- drop obsolete beforeinput listener comments in index.js

## Testing
- `node --experimental-modules -e "import('./crossword.js').then(()=>console.log('ok')).catch(err=>console.error(err))"`
- `node --experimental-modules -e "import('./index.js').then(()=>console.log('index ok')).catch(err=>console.error(err))"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68570cbcfa908325ac55f783a4b0f1ee