### PR TITLE
Update docs to reference crossword.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,17 @@
 
 This project displays an interactive crossword in modern JavaScript and HTML.
 Puzzle data is loaded from an XML file specified via the `puzzle` URL parameter
-(default `social_deduction_ok.xml`) and rendered by `index.js` (an ES module).
+(default `social_deduction_ok.xml`) and rendered by `crossword.js` (imported by
+the small `index.js` entry module).
 
 Open `index.html` in a browser to run the viewer.
 
 Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parser.js` handles XML parsing.
 ## Agent Tasks
 - Maintain user input handling and diagnostic helpers.
-- Keep the code modular and readable. `index.js` exports a `crossword` instance
-  that exposes helper methods such as `testGridIsBuilt()` and
-  `testCluesPresent()`.
+- Keep the code modular and readable. `crossword.js` defines the `Crossword`
+  class with helper methods such as `testGridIsBuilt()` and `testCluesPresent()`.
+  A single instance is created in `index.js` and exported for debugging.
 - Update this file when AGENT guidance changes and log notable updates in
   `CHANGELOG.md`.
 
@@ -54,9 +55,9 @@ Major modules: `crossword.js` implements the `Crossword` class and `puzzle-parse
 - **Reveal features**: `revealCurrentClue()` and `revealGrid()` fill in answers
   after the user confirms via a custom overlay.
  - **Author metadata**: `parsePuzzle()` reads `<creator>` or `<author>` from the
-   puzzle file's `<metadata>` section and returns it as `author`. `index.js`
-   shows "Crossword by ..." in the `#puzzle-author` element when a name is
-   provided and hides the element if none is found. The page always displays
+   puzzle file's `<metadata>` section and returns it as `author`. `crossword.js`
+   exposes this value so the entry script can show "Crossword by ..." in the
+   `#puzzle-author` element when a name is provided. The page always displays
    "Page by Niall C" using the `#page-credit` element.
 
 ## Repository Practices

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Parse puzzle data from the XML file specified in the URL (default `social_deduct
 ## Files
 
 - `index.html` — main page
-- `index.js` — JS logic (loaded as an ES module)
-- `crossword.js` — Crossword class implementation
+- `crossword.js` — Crossword class implementation and main logic (loaded as an ES module)
+- `index.js` — minimal entry script that creates a `Crossword` instance
 - `puzzle-parser.js` — puzzle parsing utilities
 - `social_deduction_ok.xml` — example puzzle data file loaded by default via fetch
 
@@ -40,7 +40,8 @@ See [CHANGELOG.md](CHANGELOG.md) for a summary of updates.
 
 Open `index.html` in a modern browser.
 
-`index.js` exports a `crossword` instance and also attaches it to `window.crossword` for debugging from the console.
+`crossword.js` defines the `Crossword` class. The entry script `index.js` creates
+an instance and attaches it to `window.crossword` for debugging from the console.
 
 Use the "Copy Share Link" button to copy a URL representing your current grid state.
 
@@ -68,7 +69,8 @@ const TEST_MODE = true;
 
 Reload `index.html` in your browser after making this change. Open the browser's
 developer tools console (usually with <kbd>F12</kbd> or via "Inspect" → "Console" )
-and run the helper functions provided by `index.js`:
+and run the helper functions provided by `crossword.js` (exposed via the
+`crossword` instance):
 
 - `testGridIsBuilt()` — returns `true` if the grid has been created.
 - `testCluesPresent()` — returns `true` if clues are displayed.


### PR DESCRIPTION
## Summary
- fix AGENTS.md instructions to highlight crossword.js
- refresh README instructions to reference crossword.js

## Testing
- `node -e "import('./crossword.js').then(m=>console.log(Object.keys(m)))"`

------
https://chatgpt.com/codex/tasks/task_e_6857191ca1d883259e2787f2d6cf9115