### PR TITLE
Show active crossword clue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ All notable changes to this project will be documented in this file.
 - Cells allow text selection to avoid overwrite issues.
 - Debug log element created only when `TEST_MODE` is true.
 - Cells now default to a white background so 1px black grid lines show correctly
+- Active clue text now displays above and below the grid

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - Thin black lines separate each cell using a 1px grid gap
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again
 - "Reveal Word" and "Reveal Grid" buttons fill answers after a confirmation prompt
+- The currently selected clue appears above and below the grid
 
 See [CHANGELOG.md](CHANGELOG.md) for a summary of updates.
 

--- a/crossword.js
+++ b/crossword.js
@@ -439,6 +439,42 @@ export default class Crossword {
         clueEl.classList.add('highlight');
       }
     }
+
+    this.updateCurrentClue();
+  }
+
+  updateCurrentClue() {
+    const topEl = document.getElementById('active-clue-top');
+    const bottomEl = document.getElementById('active-clue-bottom');
+    if (!topEl && !bottomEl) return;
+
+    if (!this.selectedCell) {
+      if (topEl) topEl.textContent = '';
+      if (bottomEl) bottomEl.textContent = '';
+      return;
+    }
+
+    const cells = getWordCells(this.puzzleData, this.cellEls, this.selectedCell, this.currentDirection);
+    if (cells.length === 0) {
+      if (topEl) topEl.textContent = '';
+      if (bottomEl) bottomEl.textContent = '';
+      return;
+    }
+
+    const clueNumber = cells[0].data.number;
+    const clues = this.currentDirection === 'across'
+      ? this.puzzleData.cluesAcross
+      : this.puzzleData.cluesDown;
+    const clue = clues.find(cl => cl.number === clueNumber);
+    if (!clue) {
+      if (topEl) topEl.textContent = '';
+      if (bottomEl) bottomEl.textContent = '';
+      return;
+    }
+    const enumStr = clue.enumeration || clue.length;
+    const text = `${clue.number}. ${clue.text} (${enumStr})`;
+    if (topEl) topEl.textContent = text;
+    if (bottomEl) bottomEl.textContent = text;
   }
 
   clearFeedback() {

--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
             <button id="reveal-clue">Reveal Word</button>
             <button id="reveal-grid">Reveal Grid</button>
         </div>
+        <div id="active-clue-top" class="active-clue"></div>
         <div id="grid"></div>
+        <div id="active-clue-bottom" class="active-clue"></div>
     </div>
 
     <div id="clues">

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ function initCrossword(xmlData) {
   const firstCell = findFirstLetterCell(crossword.puzzleData, crossword.cellEls);
   if (firstCell) {
     crossword.selectCell(firstCell);
+    crossword.updateCurrentClue();
   }
 
   crossword.copyLinkButton = document.getElementById('copy-link');

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,12 @@
             margin-bottom: 1em;
         }
 
+        .active-clue {
+            font-size: 0.8em;
+            text-align: center;
+            margin: 0.25em 0;
+        }
+
 
         #confirm-overlay {
             position: fixed;


### PR DESCRIPTION
## Summary
- show active clue above and below the grid
- style active clue text
- keep clue display updated while navigating
- expose current clue after the first cell is selected
- document the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857bb82abb8832593524b9b52dbba94