### PR TITLE
Improve pointer event handling for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable changes to this project will be documented in this file.
 - Debug log element created only when `TEST_MODE` is true.
 - Cells now default to a white background so 1px black grid lines show correctly
 - Active clue text now displays above and below the grid
+- Cell selection now happens on pointerup with a small-movement check so scrolling works on touch devices. README updated accordingly.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while each cell listens for the `input` event so mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
 Cells may be selected normally so you can highlight a letter before typing to replace it.
 
-### Clue clicking
-
-Clues are no longer clickable to prevent accidental scrolling on mobile devices. The helper method `selectClue()` remains for debugging but is not bound to the interface.
-
 ### Solved clues
 
 When all letters for a clue are filled in the clue becomes faint and now shows a light strike-through. Clicking a solved clue no longer jumps to that answer.

--- a/crossword.js
+++ b/crossword.js
@@ -46,6 +46,7 @@ export default class Crossword {
     this.feedbackCells = [];
     this.copyLinkButton = null;
     this.cellEls = [];
+    this.pointerInfo = null;
     this.puzzleData = parsePuzzle(xmlData);
     if (TEST_MODE) {
       this.debugEl = document.createElement('pre');
@@ -103,8 +104,30 @@ export default class Crossword {
       cell.setAttribute('inputmode', 'text');
       cell.tabIndex = 0;
       cell.addEventListener('pointerdown', (e) => {
-        this.selectCell(cell);
-        e.preventDefault();
+        this.pointerInfo = {
+          cell,
+          pointerId: e.pointerId,
+          x: e.clientX,
+          y: e.clientY
+        };
+      });
+      cell.addEventListener('pointerup', (e) => {
+        if (!this.pointerInfo || this.pointerInfo.pointerId !== e.pointerId) {
+          this.pointerInfo = null;
+          return;
+        }
+        const dx = e.clientX - this.pointerInfo.x;
+        const dy = e.clientY - this.pointerInfo.y;
+        const dist = Math.hypot(dx, dy);
+        const sameCell = this.pointerInfo.cell === cell;
+        this.pointerInfo = null;
+        if (sameCell && dist < 10) {
+          this.selectCell(cell);
+          e.preventDefault();
+        }
+      });
+      cell.addEventListener('pointercancel', () => {
+        this.pointerInfo = null;
       });
 
       // Unified input handler for both mobile and desktop.


### PR DESCRIPTION
## Summary
- update `createCellElement` to track pointer coordinates and defer selection to pointerup
- add pointerup and pointercancel handlers
- document improved tap behavior in CHANGELOG
- remove clue click warning from README

## Testing
- `node index.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6857bd3f90a8832588c2ef23b45844ef