### PR TITLE
Restore clue tapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ All notable changes to this project will be documented in this file.
 - Cells now default to a white background so 1px black grid lines show correctly
 - Active clue text now displays above and below the grid
 - Cell selection now happens on pointerup with a small-movement check so scrolling works on touch devices. README updated accordingly.
+- Clue tapping restored; selecting a clue scrolls the grid into view

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [SETTERS.md](SETTERS.md) for guidance on writing your own crossword file and
 - "Check Letter" and "Check Word" buttons highlight incorrect entries until you type again
 - "Reveal Word" and "Reveal Grid" buttons fill answers after a confirmation prompt
 - The currently selected clue appears above and below the grid
+- Tap any clue to select it and scroll the grid into view
 
 See [CHANGELOG.md](CHANGELOG.md) for a summary of updates.
 
@@ -52,10 +53,11 @@ Use the "Copy Share Link" button to copy a URL representing your current grid st
 
 Each grid cell is `contenteditable` so the on-screen keyboard appears on mobile devices. Keyboard events are attached at the document level: `keydown` covers desktop input while each cell listens for the `input` event so mobile browsers work correctly. The handler calls `preventDefault()` on `keydown` so characters are not inserted twice.
 Cells may be selected normally so you can highlight a letter before typing to replace it.
+Tapping a clue is the normal way to jump to its answer and the grid will scroll into view.
 
 ### Solved clues
 
-When all letters for a clue are filled in the clue becomes faint and now shows a light strike-through. Clicking a solved clue no longer jumps to that answer.
+When all letters for a clue are filled in, the clue becomes faint and shows a light strike-through. You can still tap a solved clue to highlight its answer.
 
 ## Testing
 

--- a/crossword.js
+++ b/crossword.js
@@ -245,7 +245,33 @@ export default class Crossword {
       li.appendChild(num);
       const enumStr = cl.enumeration || cl.length;
       li.appendChild(document.createTextNode(cl.text + ' (' + enumStr + ')'));
-      // clue clicks were removed to prevent unwanted scrolling on mobile
+      li.addEventListener('pointerdown', (e) => {
+        this.pointerInfo = {
+          element: li,
+          pointerId: e.pointerId,
+          x: e.clientX,
+          y: e.clientY
+        };
+      });
+      li.addEventListener('pointerup', (e) => {
+        if (!this.pointerInfo || this.pointerInfo.pointerId !== e.pointerId) {
+          this.pointerInfo = null;
+          return;
+        }
+        const dx = e.clientX - this.pointerInfo.x;
+        const dy = e.clientY - this.pointerInfo.y;
+        const dist = Math.hypot(dx, dy);
+        const sameEl = this.pointerInfo.element === li;
+        this.pointerInfo = null;
+        if (sameEl && dist < 10) {
+          this.selectClue(cl.number, 'across');
+          document.getElementById('grid')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          e.preventDefault();
+        }
+      });
+      li.addEventListener('pointercancel', () => {
+        this.pointerInfo = null;
+      });
       acrossEl.appendChild(li);
     });
 
@@ -258,7 +284,33 @@ export default class Crossword {
       li.appendChild(num);
       const enumStr = cl.enumeration || cl.length;
       li.appendChild(document.createTextNode(cl.text + ' (' + enumStr + ')'));
-      // clue clicks were removed to prevent unwanted scrolling on mobile
+      li.addEventListener('pointerdown', (e) => {
+        this.pointerInfo = {
+          element: li,
+          pointerId: e.pointerId,
+          x: e.clientX,
+          y: e.clientY
+        };
+      });
+      li.addEventListener('pointerup', (e) => {
+        if (!this.pointerInfo || this.pointerInfo.pointerId !== e.pointerId) {
+          this.pointerInfo = null;
+          return;
+        }
+        const dx = e.clientX - this.pointerInfo.x;
+        const dy = e.clientY - this.pointerInfo.y;
+        const dist = Math.hypot(dx, dy);
+        const sameEl = this.pointerInfo.element === li;
+        this.pointerInfo = null;
+        if (sameEl && dist < 10) {
+          this.selectClue(cl.number, 'down');
+          document.getElementById('grid')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          e.preventDefault();
+        }
+      });
+      li.addEventListener('pointercancel', () => {
+        this.pointerInfo = null;
+      });
       downEl.appendChild(li);
     });
     this.updateClueCompletion();


### PR DESCRIPTION
## Summary
- reattach pointer handlers to clues using the same small-movement check as cells
- call `selectClue` and scroll the grid when a clue is activated
- document clue tapping in the README
- note the restored behaviour in the changelog

## Testing
- `node -c crossword.js`

------
https://chatgpt.com/codex/tasks/task_e_6857be3ffb9c8325961c4aae851a2357