### PR TITLE
Improve clue spacing on smaller screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
             flex-direction: row;
             flex-wrap: wrap;
             align-items: flex-start;
-            gap: 2rem;
+            gap: clamp(0.5rem, 3vw, 2rem);
             background-color: #eef6ff; /* pastel blue background */
         }
 
@@ -19,7 +19,6 @@
             border: 1px solid #000;
             position: relative;
             background-color: #000; /* lines rendered via grid background */
-            margin-top: 15px; /* spacing from buttons */
         }
 
         .cell {
@@ -206,7 +205,7 @@
 
         #clues {
             display: flex;
-            gap: 2rem;
+            gap: clamp(0.5rem, 2vw, 2rem);
             max-width: 600px;
         }
 
@@ -227,7 +226,7 @@
                 max-width: none;
             }
             #grid {
-                margin-bottom: 1rem;
+                margin-bottom: 1rem; /* space before clue list when stacked */
             }
         }
 


### PR DESCRIPTION
## Summary
- adjust body and clue list gaps using CSS `clamp`
- remove fixed margin above the grid
- ensure stacked layouts still have space before the clue list

## Testing
- `git status --short`
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6857c367cf3c832586fd770dc7e5f7f6