### PR TITLE
Improve clue spacing on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ All notable changes to this project will be documented in this file.
 - Active clue text now displays above and below the grid
 - Cell selection now happens on pointerup with a small-movement check so scrolling works on touch devices. README updated accordingly.
 - Clue tapping restored; selecting a clue scrolls the grid into view
+- Clue spacing refined with CSS `clamp()`; grid margin removed so active clues sit closer

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
             flex-direction: row;
             flex-wrap: wrap;
             align-items: flex-start;
-            gap: 2rem;
+            gap: clamp(0.5rem, 3vw, 2rem);
             background-color: #eef6ff; /* pastel blue background */
         }
 
@@ -19,7 +19,6 @@
             border: 1px solid #000;
             position: relative;
             background-color: #000; /* lines rendered via grid background */
-            margin-top: 15px; /* spacing from buttons */
         }
 
         .cell {
@@ -138,6 +137,10 @@
             margin: 0.25em 0;
         }
 
+        #active-clue-bottom {
+            margin-bottom: clamp(0.5rem, 3vw, 1rem);
+        }
+
 
         #confirm-overlay {
             position: fixed;
@@ -206,7 +209,7 @@
 
         #clues {
             display: flex;
-            gap: 2rem;
+            gap: clamp(0.5rem, 2vw, 2rem);
             max-width: 600px;
         }
 
@@ -227,7 +230,7 @@
                 max-width: none;
             }
             #grid {
-                margin-bottom: 1rem;
+                margin-bottom: 0; /* margin handled by bottom clue */
             }
         }
 


### PR DESCRIPTION
## Summary
- adjust body and clue list gaps using CSS `clamp`
- remove fixed margin above the grid
- ensure stacked layouts still have space before the clue list
- tweak bottom clue margin so both active clues sit close to the grid

## Testing
- `git status --short`
- `git show --stat -1`

------
https://chatgpt.com/codex/tasks/task_e_6857c367cf3c832586fd770dc7e5f7f6